### PR TITLE
new toggles to mapLayersControl: hastus, longId, shortId

### DIFF
--- a/src/components/controls/checkbox.scss
+++ b/src/components/controls/checkbox.scss
@@ -33,7 +33,7 @@
 
 /* On mouse-over, add a slightly grey background color */
 .container:hover input ~ .checkmark {
-    background-color: rgb(248, 248, 248);
+    background-color: #e0e0e0;
 }
 
 /* When the checkbox is checked, add a blue background */
@@ -43,7 +43,7 @@
 
 /* On checked input mouse-over, add a slightly grey background color */
 .container input:checked:hover ~ .checkmark {
-    background-color: rgb(248, 248, 248);
+    background-color: #e0e0e0;
 }
 
 /* Create the checkmark/indicator (hidden when not checked) */

--- a/src/components/map/layers/NodeLayer.tsx
+++ b/src/components/map/layers/NodeLayer.tsx
@@ -5,7 +5,7 @@ import { INode } from '~/models';
 import NodeType from '~/enums/nodeType';
 import { PopupStore } from '~/stores/popupStore';
 import { ToolbarStore } from '~/stores/toolbarStore';
-import { MapStore } from '~/stores/mapStore';
+import { MapStore, NodeLabel } from '~/stores/mapStore';
 import NodeMarker from './NodeMarker';
 
 interface INodeLayerProps {
@@ -17,11 +17,38 @@ interface INodeLayerProps {
     mapStore?: MapStore;
 }
 
+const NODE_LABEL_MIN_ZOOM = 14;
+
 @inject('popupStore', 'toolbarStore', 'mapStore')
 @observer
 export default class NodeLayer extends Component<INodeLayerProps> {
     private isSelected(node: INode) {
         return this.props.mapStore!.selectedNodeId === node.id;
+    }
+
+    private getLabels(): string[] {
+        const node = this.props.node;
+        const visibleNodeLabels = this.props.mapStore!.visibleNodeLabels;
+        const zoom = this.props.mapStore!.zoom;
+
+        if (!node
+            || visibleNodeLabels.length === 0
+            || zoom < NODE_LABEL_MIN_ZOOM) return [];
+
+        const labels: string[] = [];
+        if (visibleNodeLabels.includes(NodeLabel.hastusId)) {
+            if (node.stop && node.stop.hastusId) {
+                labels.push(node.stop.hastusId);
+            }
+        }
+        if (visibleNodeLabels.includes(NodeLabel.longNodeId)) {
+            labels.push(node.id);
+        }
+        if (visibleNodeLabels.includes(NodeLabel.shortNodeId)) {
+            labels.push(node.shortId);
+        }
+
+        return labels;
     }
 
     render() {
@@ -46,6 +73,7 @@ export default class NodeLayer extends Component<INodeLayerProps> {
             <NodeMarker
                 nodeType={nodeType}
                 isSelected={this.isSelected(node)}
+                labels={this.getLabels()}
                 latLng={latLng}
                 onContextMenu={openPopup}
                 stop={node.stop ? node.stop : undefined}

--- a/src/components/map/layers/NodeMarker.tsx
+++ b/src/components/map/layers/NodeMarker.tsx
@@ -26,11 +26,11 @@ interface INodeMarkerProps {
     onClick?: Function;
     isDraggable?: boolean;
     stop?: IStop;
+    labels?: string[];
     isNeighborMarker?: boolean; // used for highlighting a node when creating new routePath
 }
 
 const DEFAULT_RADIUS = 25;
-const HASTUS_MIN_ZOOM = 16;
 
 @inject('mapStore')
 @observer
@@ -81,13 +81,14 @@ export default class NodeMarker extends Component<INodeMarkerProps> {
     }
 
     private renderMarkerLabel = () => {
-        const zoom = this.props.mapStore!.zoom;
-        const hastusId = this.props.stop ? this.props.stop!.hastusId : null;
-        if (!hastusId || zoom < HASTUS_MIN_ZOOM) return null;
-
+        if (!this.props.labels) return null;
         return (
-            <div className={s.hastusIdLabel}>
-                {hastusId}
+            <div className={s.nodeLabel}>
+                {this.props.labels.map((label, index) => {
+                    return (
+                        <div key={index}>{label}</div>
+                    );
+                })}
             </div>
         );
     }

--- a/src/components/map/layers/nodeMarker.scss
+++ b/src/components/map/layers/nodeMarker.scss
@@ -71,14 +71,6 @@
         width: 20px;
     }
 
-    .hastusIdLabel {
-        position: absolute;
-        left: 20px;
-        top: 3px;
-        font-weight: 600;
-        text-shadow: 0 0 5px white, 0 0 5px white;
-    }
-
     .neighborMarker {
         position: absolute;
         width: 20px;
@@ -101,4 +93,12 @@
     stroke: none;
     fill: $busBlue;
     fill-opacity: 0.3;
+}
+
+.nodeLabel {
+    position: absolute;
+    left: 20px;
+    top: 3px;
+    font-weight: 600;
+    text-shadow: 0 0 5px white, 0 0 5px white;
 }

--- a/src/components/map/mapControls/MapLayersControl.tsx
+++ b/src/components/map/mapControls/MapLayersControl.tsx
@@ -104,14 +104,14 @@ export default class MapLayersControl extends React.Component
                             <Checkbox
                                 onClick={this.toggleNodeLabel(NodeLabel.longNodeId)}
                                 checked={MapStore.isNodeLabelVisible(NodeLabel.longNodeId)}
-                                text={'Pitkä solmun id'}
+                                text={'Pitkä solmun tunnus'}
                             />
                         </div>
                         <div className={s.checkboxContainer}>
                             <Checkbox
                                 onClick={this.toggleNodeLabel(NodeLabel.shortNodeId)}
                                 checked={MapStore.isNodeLabelVisible(NodeLabel.shortNodeId)}
-                                text={'Lyhyt solmun id'}
+                                text={'Lyhyt solmun tunnus'}
                             />
                         </div>
                     <div className={s.sectionDivider} />

--- a/src/components/map/mapControls/MapLayersControl.tsx
+++ b/src/components/map/mapControls/MapLayersControl.tsx
@@ -4,11 +4,12 @@ import { IoMdMap } from 'react-icons/io';
 import { TransitToggleButtonBar, Checkbox } from '~/components/controls/';
 import TransitType from '~/enums/transitType';
 import NetworkStore from '~/stores/networkStore';
+import MapStore, { NodeLabel } from '~/stores/mapStore';
 import { RadioButton } from '../../controls';
 import * as s from './mapLayersControl.scss';
 
 interface IMapLayersControlState {
-    selectedOption: option;
+    selectedMapOption: option;
 }
 
 interface IMapLayersControlProps {
@@ -26,14 +27,8 @@ export default class MapLayersControl extends React.Component
     constructor (props: any) {
         super(props);
         this.state = {
-            selectedOption: option.MAP,
+            selectedMapOption: option.MAP,
         };
-    }
-
-    private toggleRadioButton = (option: option) => () => {
-        this.setState({
-            selectedOption: option,
-        });
     }
 
     public toggleTransitType = (type: TransitType) => {
@@ -52,6 +47,16 @@ export default class MapLayersControl extends React.Component
         NetworkStore.togglePointVisibility();
     }
 
+    public toggleNodeLabel = (nodeLabel: NodeLabel) => () => {
+        MapStore.toggleVisibleNodeLabel(nodeLabel);
+    }
+
+    private toggleMapOption = (option: option) => () => {
+        this.setState({
+            selectedMapOption: option,
+        });
+    }
+
     render() {
         return (
             <div className={s.mapLayerControlView}>
@@ -60,52 +65,72 @@ export default class MapLayersControl extends React.Component
                 </div>
 
                 <div className={s.mapLayersContainer}>
-                    <div className={s.networkToggleView}>
-                        <div className={s.inputTitle}>VERKKO</div>
-                        <TransitToggleButtonBar
-                            toggleSelectedTransitType={this.toggleTransitType}
-                            selectedTransitTypes={NetworkStore.selectedTransitTypes}
-                        />
-                        <div className={s.checkboxContainer}>
-                            <Checkbox
-                                onClick={this.toggleLinkVisibility}
-                                checked={NetworkStore.isLinksVisible}
-                                text={'Näytä alueen linkit'}
-                            />
-                        </div>
-                        <div className={s.checkboxContainer}>
-                            <Checkbox
-                                onClick={this.togglePointVisibility}
-                                checked={NetworkStore.isPointsVisible}
-                                text={'Näytä linkkien pisteet'}
-                            />
-                        </div>
-                        <div className={s.checkboxContainer}>
-                            <Checkbox
-                                onClick={this.toggleNodeVisibility}
-                                checked={NetworkStore.isNodesVisible}
-                                text={'Näytä alueen solmut'}
-                            />
-                        </div>
-                    </div>
-                    <div className={s.mapLayerToggleView}>
-                        <div className={s.inputTitle}>KARTTA</div>
-                        <RadioButton
-                            onClick={this.toggleRadioButton(option.MAP)}
-                            checked={this.state.selectedOption === option.MAP}
-                            text={option.MAP}
-                        />
-                        <RadioButton
-                            onClick={this.toggleRadioButton(option.SATELLITE)}
-                            checked={this.state.selectedOption === option.SATELLITE}
-                            text={option.SATELLITE}
-                        />
-                        <RadioButton
-                            onClick={this.toggleRadioButton(option.TERRAIN)}
-                            checked={this.state.selectedOption === option.TERRAIN}
-                            text={option.TERRAIN}
+                    <div className={s.inputTitle}>VERKKO</div>
+                    <TransitToggleButtonBar
+                        toggleSelectedTransitType={this.toggleTransitType}
+                        selectedTransitTypes={NetworkStore.selectedTransitTypes}
+                    />
+                    <div className={s.checkboxContainer}>
+                        <Checkbox
+                            onClick={this.toggleLinkVisibility}
+                            checked={NetworkStore.isLinksVisible}
+                            text={'Näytä alueen linkit'}
                         />
                     </div>
+                    <div className={s.checkboxContainer}>
+                        <Checkbox
+                            onClick={this.togglePointVisibility}
+                            checked={NetworkStore.isPointsVisible}
+                            text={'Näytä linkkien pisteet'}
+                        />
+                    </div>
+                    <div className={s.checkboxContainer}>
+                        <Checkbox
+                            onClick={this.toggleNodeVisibility}
+                            checked={NetworkStore.isNodesVisible}
+                            text={'Näytä alueen solmut'}
+                        />
+                    </div>
+                    <div className={s.sectionDivider} />
+                    <div className={s.inputTitle}>SOLMUT</div>
+                        <div className={s.checkboxContainer}>
+                            <Checkbox
+                                onClick={this.toggleNodeLabel(NodeLabel.hastusId)}
+                                checked={MapStore.isNodeLabelVisible(NodeLabel.hastusId)}
+                                text={'Hastus id'}
+                            />
+                        </div>
+                        <div className={s.checkboxContainer}>
+                            <Checkbox
+                                onClick={this.toggleNodeLabel(NodeLabel.longNodeId)}
+                                checked={MapStore.isNodeLabelVisible(NodeLabel.longNodeId)}
+                                text={'Pitkä solmun id'}
+                            />
+                        </div>
+                        <div className={s.checkboxContainer}>
+                            <Checkbox
+                                onClick={this.toggleNodeLabel(NodeLabel.shortNodeId)}
+                                checked={MapStore.isNodeLabelVisible(NodeLabel.shortNodeId)}
+                                text={'Lyhyt solmun id'}
+                            />
+                        </div>
+                    <div className={s.sectionDivider} />
+                    <div className={s.inputTitle}>KARTTA</div>
+                    <RadioButton
+                        onClick={this.toggleMapOption(option.MAP)}
+                        checked={this.state.selectedMapOption === option.MAP}
+                        text={option.MAP}
+                    />
+                    <RadioButton
+                        onClick={this.toggleMapOption(option.SATELLITE)}
+                        checked={this.state.selectedMapOption === option.SATELLITE}
+                        text={option.SATELLITE}
+                    />
+                    <RadioButton
+                        onClick={this.toggleMapOption(option.TERRAIN)}
+                        checked={this.state.selectedMapOption === option.TERRAIN}
+                        text={option.TERRAIN}
+                    />
                 </div>
             </div>
         );

--- a/src/components/map/mapControls/mapLayersControl.scss
+++ b/src/components/map/mapControls/mapLayersControl.scss
@@ -7,6 +7,17 @@
     width: 100%;
     height: 100%;
 
+    .checkboxContainer {
+        padding-top: 10px;
+        display: flex;
+    }
+
+    .sectionDivider {
+        margin: 10px 0px 10px 0px;
+        border-bottom: 1px solid rgb(222, 222, 222);
+        text-align: left;
+    }
+
     .mapLayerControlIcon {
         display: flex;
         font-size: $largeFontSize;
@@ -25,19 +36,8 @@
         background-color: white;
         border-radius: 3px;
         box-shadow: 0 0 4px #666666;
-        z-index: 1;
         padding: 20px;
-
-        .networkToggleView {
-            border-bottom: 1px solid rgb(222, 222, 222);
-            text-align: left;
-            padding-bottom: 10px;
-
-            .checkboxContainer {
-                padding-top: 10px;
-                display: flex;
-            }
-        }
+        min-width: 250px;
 
         .inputTitle {
             font-size: 0.8rem;
@@ -46,11 +46,6 @@
             letter-spacing: 0em;
             padding-bottom: 3px;
             display: block;
-        }
-
-        .mapLayerToggleView {
-            padding-top: 10px;
-            text-align: left;
         }
     }
 }

--- a/src/factories/nodeFactory.ts
+++ b/src/factories/nodeFactory.ts
@@ -14,6 +14,9 @@ class NodeFactory {
             lon: coordinateList.coordinates[0],
             lat: coordinateList.coordinates[1],
         };
+        const shortId = externalNode.solkirjain
+            ? externalNode.solkirjain + externalNode.sollistunnus
+            : externalNode.sollistunnus;
         const nodeStop = externalNode.pysakkiBySoltunnus;
         const type = getNodeType(externalNode.soltyyppi);
 
@@ -27,6 +30,7 @@ class NodeFactory {
         return {
             type,
             coordinates,
+            shortId,
             id: externalNode.soltunnus,
             stop: nodeStop ? NodeStopFactory.createStop(nodeStop) : undefined,
             measurementDate: externalNode.mittpvm,

--- a/src/models/INode.ts
+++ b/src/models/INode.ts
@@ -4,6 +4,7 @@ import { ICoordinate } from '.';
 
 export default interface INode {
     id: string;
+    shortId: string;
     stop?: IStop;
     type: NodeType;
     coordinates: ICoordinate;

--- a/src/models/externals/IExternalNode.ts
+++ b/src/models/externals/IExternalNode.ts
@@ -7,6 +7,8 @@ export default interface IExternalNode {
     mittpvm: string;
     solkuka: string;
     soltunnus: string;
+    sollistunnus: string;
+    solkirjain: string;
     soltyyppi: string;
     solviimpvm: string;
 }

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -147,6 +147,8 @@ const nodeQueryFields = `
     solx,
     soly,
     soltunnus,
+    sollistunnus,
+    solkirjain,
     soltyyppi,
     solkirjain,
     geojson,

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -9,6 +9,12 @@ const INITIAL_COORDINATES = new LatLng(
 );
 const INITIAL_ZOOM = 15;
 
+export enum NodeLabel {
+    hastusId,
+    longNodeId,
+    shortNodeId,
+}
+
 export class MapStore {
 
     @observable private _coordinates: LatLng;
@@ -17,6 +23,7 @@ export class MapStore {
     @observable private _displayCoordinateSystem:CoordinateSystem;
     @observable private _zoom:number;
     @observable private _selectedNodeId: string|null;
+    @observable private _visibleNodeLabels: NodeLabel[];
 
     constructor() {
         this._coordinates = INITIAL_COORDINATES;
@@ -24,6 +31,10 @@ export class MapStore {
         this._isMapFullscreen = false;
         this._routes = [];
         this._displayCoordinateSystem = CoordinateSystem.EPSG4326;
+        this._visibleNodeLabels = [
+            NodeLabel.hastusId,
+            NodeLabel.longNodeId,
+        ];
     }
 
     @computed
@@ -34,11 +45,6 @@ export class MapStore {
     @computed
     get zoom(): number {
         return this._zoom;
-    }
-
-    @action
-    setZoom(zoom: number) {
-        this._zoom = zoom;
     }
 
     @computed
@@ -69,9 +75,19 @@ export class MapStore {
         return this._selectedNodeId;
     }
 
+    @computed
+    get visibleNodeLabels(): NodeLabel[] {
+        return this._visibleNodeLabels;
+    }
+
     @action
     public setCoordinates(lat: number, lon: number) {
         this._coordinates = new LatLng(lat, lon);
+    }
+
+    @action
+    setZoom(zoom: number) {
+        this._zoom = zoom;
     }
 
     @action
@@ -95,6 +111,20 @@ export class MapStore {
     @action
     public setSelectedNodeId(id: string|null) {
         this._selectedNodeId = id;
+    }
+
+    @action
+    public toggleVisibleNodeLabel(nodeLabel: NodeLabel) {
+        if (this._visibleNodeLabels.includes(nodeLabel)) {
+            this._visibleNodeLabels = this._visibleNodeLabels.filter(t => t !== nodeLabel);
+        } else {
+            // Need to do concat (instead of push) to trigger ReactionDisposer watcher
+            this._visibleNodeLabels = this._visibleNodeLabels.concat([nodeLabel]);
+        }
+    }
+
+    public isNodeLabelVisible(nodeLabel: NodeLabel) {
+        return this._visibleNodeLabels.includes(nodeLabel);
     }
 
 }

--- a/src/stores/networkStore.ts
+++ b/src/stores/networkStore.ts
@@ -16,6 +16,7 @@ export enum NodeSize {
 
 export class NetworkStore {
     @observable private _selectedTransitTypes: TransitType[];
+    // TODO: Refactor to use a single array: visibleMapLayers, just like NodeLabel[] at mapStore
     @observable private _isLinksVisible: boolean;
     @observable private _isNodesVisible: boolean;
     @observable private _isPointsVisible: boolean;


### PR DESCRIPTION
Closes #465 

Pretty straightforward task.

NodeLayer can now take an array of strings and it will display label with each string on its own row. NodeLayer doesn't know anymore what labels it shows.

See comment:
// TODO: Refactor to use a single array: visibleMapLayers, just like NodeLabel[] at mapStore
if that NodeLabel[] considered a good practice, we should refactor to use visibleMapLayers too.