### PR TITLE
network nodes now show transit color if only one transit type is present

### DIFF
--- a/src/components/map/layers/NetworkLayers.scss
+++ b/src/components/map/layers/NetworkLayers.scss
@@ -1,0 +1,64 @@
+@import '../../shared/styles/common.scss';
+// TODO replace hexes with imported colors.
+
+.stop {
+  stroke: #3e3c87;
+  fill: $white;
+  opacity: 1;
+  fill-opacity: 1;
+
+  &.bus {
+    stroke: $busBlue;
+  }
+
+  &.tram {
+    stroke: $tramGreen;
+  }
+
+  &.train {
+    stroke: $trainPurple;
+  }
+
+  &.subway {
+    stroke: $subwayOrange;
+  }
+
+  &.ferry {
+    stroke: $ferryBlue;
+  }
+}
+
+.crossroad {
+  stroke: #727272;
+  fill: #c6c6c6;
+  opacity: 1;
+  fill-opacity: 1;
+
+  &.bus {
+    fill: $busBlue;
+  }
+
+  &.tram {
+    fill: $tramGreen;
+  }
+
+  &.train {
+    fill: $trainPurple;
+  }
+
+  &.subway {
+    fill: $subwayOrange;
+  }
+
+  &.ferry {
+    fill: $ferryBlue;
+  }
+}
+
+.border {
+  stroke: #c900ff;
+}
+
+.hidden {
+  display: none;
+}

--- a/src/components/map/layers/NetworkLayers.tsx
+++ b/src/components/map/layers/NetworkLayers.tsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
-import { observer, inject } from 'mobx-react';
+import { inject, observer } from 'mobx-react';
 import { toJS } from 'mobx';
+import classNames from 'classnames';
 import { EditNetworkStore } from '~/stores/editNetworkStore';
-import { NetworkStore, NodeSize, MapLayer } from '~/stores/networkStore';
+import { MapLayer, NetworkStore, NodeSize } from '~/stores/networkStore';
 import { RoutePathStore } from '~/stores/routePathStore';
 import { ToolbarStore } from '~/stores/toolbarStore';
 import TransitTypeHelper from '~/util/transitTypeHelper';
@@ -10,20 +11,12 @@ import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
 import NodeType from '~/enums/nodeType';
 import TransitType from '~/enums/transitType';
 import VectorGridLayer from './VectorGridLayer';
+import * as s from './NetworkLayers.scss';
 
 enum GeoserverLayer {
     Node = 'solmu',
     Link = 'linkki',
     Point = 'piste',
-}
-
-// TODO: import these from NodeMarker's .scss
-enum NodeColors {
-    CROSSROAD_COLOR = '#727272',
-    CROSSROAD_FILL_COLOR = '#c6c6c6',
-    STOP_COLOR = '#3e3c87',
-    STOP_FILL_COLOR = '#FFF',
-    MUNICIPALITY_BORDER_COLOR = '#c900ff',
 }
 
 interface INetworkLayersProps {
@@ -108,10 +101,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
             return true;
         }
         const node = this.props.editNetworkStore!.node;
-        if (node && (node.id === startNodeId || node.id === endNodeId)) {
-            return true;
-        }
-        return false;
+        return Boolean(node && (node.id === startNodeId || node.id === endNodeId));
     }
 
     private getNodeStyle = () => {
@@ -127,19 +117,16 @@ class NetworkLayers extends Component<INetworkLayersProps> {
                 if (this.isNodeHidden(nodeId, transitTypeCodes)) {
                     return this.getEmptyStyle();
                 }
-                let color;
-                let fillColor;
+                let className;
                 switch (nodeType) {
                 case NodeType.STOP:
-                    color = NodeColors.STOP_COLOR;
-                    fillColor = NodeColors.STOP_FILL_COLOR;
+                    className = s.stop;
                     break;
                 case NodeType.CROSSROAD:
-                    color = NodeColors.CROSSROAD_COLOR;
-                    fillColor = NodeColors.CROSSROAD_FILL_COLOR;
+                    className = s.crossroad;
                     break;
                 case NodeType.MUNICIPALITY_BORDER:
-                    color = NodeColors.MUNICIPALITY_BORDER_COLOR;
+                    className = s.border;
                     break;
                 }
                 let radius: any;
@@ -153,14 +140,30 @@ class NetworkLayers extends Component<INetworkLayersProps> {
                 default:
                     throw new Error(`nodeSize not supported ${this.props.networkStore!.nodeSize}`);
                 }
+                if (transitTypeCodes && transitTypeCodes.length === 1) {
+                    switch (TransitTypeHelper
+                        .convertTransitTypeCodeToTransitType(transitTypeCodes[0])) {
+                    case TransitType.BUS:
+                            className = classNames(className, s.bus);
+                            break;
+                    case TransitType.TRAM:
+                            className = classNames(className, s.tram);
+                            break;
+                    case TransitType.SUBWAY:
+                            className = classNames(className, s.subway);
+                            break;
+                    case TransitType.TRAIN:
+                            className = classNames(className, s.train);
+                            break;
+                    case TransitType.FERRY:
+                            className = classNames(className, s.ferry);
+                            break;
+                    }
+                }
 
                 return {
-                    color,
+                    className,
                     radius,
-                    fillColor,
-                    opacity: 1,
-                    fillOpacity: 1,
-                    fill: true,
                 };
             },
         };
@@ -195,14 +198,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
     }
 
     private getEmptyStyle = () => {
-        return {
-            fillOpacity: 0,
-            stroke: false,
-            fill: false,
-            opacity: 0,
-            weight: 0,
-            radius: 0,
-        };
+        return { className: s.hidden };
     }
 
     render() {


### PR DESCRIPTION
Closes #471 
* Nodes with exactly one transit type get colored in the color of that transit type
* Moved some styling information from ts to css