### PR TITLE
Enabled editing of single link + saving edited link to editNetworkStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "html-webpack-plugin": "2.29.0",
     "jest": "22.4.2",
     "leaflet": "^1.3.4",
+    "leaflet-editable": "^1.2.0",
     "leaflet.vectorgrid": "github:chriszrc/Leaflet.VectorGrid#6bdad6d07290db04ff02ebf44830b85bcfe6c020",
     "lodash": "^4.17.11",
     "mobx": "^5.0.3",

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -13,14 +13,14 @@ import CoordinateControl from './mapControls/CoordinateControl';
 import FullscreenControl from './mapControls/FullscreenControl';
 import RouteLayer from './layers/RouteLayer';
 import UpsertRoutePathLayer from './layers/edit/UpsertRoutePathLayer';
-import EditNetworkLayer from './layers/edit/EditNetworkLayer';
+import EditLinkLayer from './layers/edit/EditLinkLayer';
+import EditNodeLayer from './layers/edit/EditNodeLayer';
 import MapLayersControl from './mapControls/MapLayersControl';
 import Toolbar from './toolbar/Toolbar';
 import EventLog from './EventLog';
 import PopupLayer from './layers/PopupLayer';
 import MeasurementControl from './mapControls/MeasurementControl';
 import * as s from './map.scss';
-import NetworkLayers from './layers/NetworkLayers';
 
 interface IMapProps {
     mapStore?: MapStore;
@@ -165,12 +165,12 @@ class LeafletMap extends React.Component<IMapProps> {
                         zoomOffset={-1}
                         // tslint:enable:max-line-length
                     />
-                    <NetworkLayers />
+                    <EditNodeLayer />
+                    <EditLinkLayer />
                     <RouteLayer
                         routes={routes}
                     />
                     <UpsertRoutePathLayer />
-                    <EditNetworkLayer />
                     <PopupLayer />
                     <Control position='topleft'>
                         <Toolbar />

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -1,5 +1,6 @@
 import { LayerContainer, Map, TileLayer, ZoomControl } from 'react-leaflet';
 import * as L from 'leaflet';
+import 'leaflet-editable';
 import { inject, observer } from 'mobx-react';
 import { IReactionDisposer, reaction, toJS } from 'mobx';
 import React from 'react';
@@ -33,6 +34,7 @@ interface IMapPropReference {
     zoom: number;
     zoomControl: false;
     id: string;
+    editable: boolean;
 }
 
 export type LeafletContext = {
@@ -142,6 +144,7 @@ class LeafletMap extends React.Component<IMapProps> {
                     ref={this.mapReference}
                     zoomControl={false}
                     id={s.mapLeaflet}
+                    editable={true}
                 >
                     <TileLayer
                         // tslint:disable:max-line-length

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -23,15 +23,15 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
     private editableLinks: L.Polyline[] = [];
 
     componentDidMount() {
-        this.reactionDisposer = reaction(() =>
-        this.props.editNetworkStore!.links,
-                                         () => {
-                                             const links = this.props.editNetworkStore!.links;
-                                             if (links.length === 0) {
-                                                 this.removeOldLinks();
-                                             }
-                                         },
-            );
+        this.reactionDisposer = reaction(
+            () => this.props.editNetworkStore!.links,
+            () => {
+                const links = this.props.editNetworkStore!.links;
+                if (links.length === 0) {
+                    this.removeOldLinks();
+                }
+            },
+        );
     }
 
     private removeOldLinks = () => {
@@ -47,7 +47,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         this.reactionDisposer();
     }
 
-    private drawEditableLinks = () => {
+    private drawEditableLink = () => {
         const links = this.props.editNetworkStore!.links;
         const map = this.props.leaflet.map;
         const isLinkView = Boolean(matchPath(navigator.getPathName(), SubSites.link));
@@ -104,7 +104,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         const isLinkViewVisible = Boolean(matchPath(navigator.getPathName(), SubSites.link));
         if (!isLinkViewVisible) return null;
 
-        this.drawEditableLinks();
+        this.drawEditableLink();
 
         return (
             this.renderNodes()

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -1,24 +1,23 @@
 import React, { Component } from 'react';
 import * as L from 'leaflet';
-import { Polyline, withLeaflet } from 'react-leaflet';
+import { withLeaflet } from 'react-leaflet';
 import { matchPath } from 'react-router';
 import { inject, observer } from 'mobx-react';
 import navigator from '~/routing/navigator';
 import SubSites from '~/routing/subSites';
 import { INode, ILink } from '~/models';
 import { EditNetworkStore } from '~/stores/editNetworkStore';
-import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
 import NodeMarker from '../mapIcons/NodeMarker';
 import { LeafletContext } from '../../Map';
 
-interface IEditNetworkLayerProps {
+interface IEditLinkLayerProps {
     editNetworkStore?: EditNetworkStore;
     leaflet: LeafletContext;
 }
 
 @inject('editNetworkStore')
 @observer
-class EditNetworkLayer extends Component<IEditNetworkLayerProps> {
+class EditLinkLayer extends Component<IEditLinkLayerProps> {
     editableLinks: L.Polyline[] = [];
 
     private drawEditableLinks() {
@@ -66,27 +65,6 @@ class EditNetworkLayer extends Component<IEditNetworkLayerProps> {
         }
     }
 
-    private renderLinks() {
-        const links = this.props.editNetworkStore!.links;
-        const isLinkView = Boolean(matchPath(navigator.getPathName(), SubSites.link));
-
-        if (isLinkView || !links) return null;
-        return links.map((link: ILink, index) => this.renderLink(link, index));
-    }
-
-    private renderLink(link: ILink, key: number) {
-        const color = TransitTypeColorHelper.getColor(link.transitType);
-        return (
-            <Polyline
-                key={key}
-                positions={link.geometry}
-                color={color}
-                weight={5}
-                opacity={0.8}
-            />
-        );
-    }
-
     private renderNodes() {
         const nodes = this.props.editNetworkStore!.nodes;
         return nodes.map(n => this.renderNode(n));
@@ -105,14 +83,15 @@ class EditNetworkLayer extends Component<IEditNetworkLayerProps> {
     }
 
     render() {
+        const isLinkViewVisible = Boolean(matchPath(navigator.getPathName(), SubSites.link));
+        if (!isLinkViewVisible) return null;
+
         this.drawEditableLinks();
+
         return (
-            <>
-                {this.renderLinks()}
-                {this.renderNodes()}
-            </>
+            this.renderNodes()
         );
     }
 }
 
-export default withLeaflet(EditNetworkLayer);
+export default withLeaflet(EditLinkLayer);

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -19,19 +19,19 @@ interface IEditLinkLayerProps {
 @inject('editNetworkStore')
 @observer
 class EditLinkLayer extends Component<IEditLinkLayerProps> {
-    private reactionDisposers: IReactionDisposer[] = [];
+    private reactionDisposer: IReactionDisposer;
     private editableLinks: L.Polyline[] = [];
 
     componentDidMount() {
-        this.reactionDisposers.push(reaction(
-            () => this.props.editNetworkStore!.links,
-            () => {
-                const links = this.props.editNetworkStore!.links;
-                if (links.length === 0) {
-                    this.removeOldLinks();
-                }
-            },
-        ));
+        this.reactionDisposer = reaction(() =>
+        this.props.editNetworkStore!.links,
+                                         () => {
+                                             const links = this.props.editNetworkStore!.links;
+                                             if (links.length === 0) {
+                                                 this.removeOldLinks();
+                                             }
+                                         },
+            );
     }
 
     private removeOldLinks = () => {
@@ -44,7 +44,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
     }
 
     componentWillUnmount() {
-        this.reactionDisposers.forEach(r => r());
+        this.reactionDisposer();
     }
 
     private drawEditableLinks = () => {

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -54,7 +54,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         if (!isLinkView || !links || !map) return;
 
         this.removeOldLinks();
-        links.map((link: ILink, index) => this.drawEditableLinkToMap(link, index));
+        links.map((link: ILink) => this.drawEditableLinkToMap(link));
 
         map.off('editable:vertex:dragend');
         map.on('editable:vertex:dragend', () => {
@@ -65,24 +65,20 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         });
     }
 
-    private drawEditableLinkToMap = (link: ILink, key: number) => {
+    private drawEditableLinkToMap = (link: ILink) => {
         const map = this.props.leaflet.map;
         if (map) {
             const editableLink = L.polyline([link.geometry]).addTo(map);
             editableLink.enableEdit();
-            const linkLatLngs = [editableLink.getLatLngs()];
-
-            // Hide first and last vertex from editableLink
-            linkLatLngs.forEach((_linkLatLng: any) => {
-                _linkLatLng.forEach((coords: any) => {
-                    const coordsToDisable = [coords[0], coords[coords.length - 1]];
-                    coordsToDisable.forEach((coordToDisable: any) => {
-                        const vertexMarker = coordToDisable.__vertex;
-                        vertexMarker.dragging.disable();
-                        vertexMarker.setOpacity(0);
-                    });
-                });
+            const latLngs = editableLink.getLatLngs() as L.LatLng[][];
+            const coords = latLngs[0];
+            const coordsToDisable = [coords[0], coords[coords.length - 1]];
+            coordsToDisable.forEach((coordToDisable: any) => {
+                const vertexMarker = coordToDisable.__vertex;
+                vertexMarker.dragging.disable();
+                vertexMarker.setOpacity(0);
             });
+
             this.editableLinks.push(editableLink);
         }
     }

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -1,0 +1,73 @@
+import React, { Component } from 'react';
+import { Polyline, withLeaflet } from 'react-leaflet';
+import { matchPath } from 'react-router';
+import { inject, observer } from 'mobx-react';
+import navigator from '~/routing/navigator';
+import SubSites from '~/routing/subSites';
+import { INode, ILink } from '~/models';
+import { EditNetworkStore } from '~/stores/editNetworkStore';
+import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
+import NodeMarker from '../mapIcons/NodeMarker';
+import { LeafletContext } from '../../Map';
+
+interface IEditNodeLayerProps {
+    editNetworkStore?: EditNetworkStore;
+    leaflet: LeafletContext;
+}
+
+@inject('editNetworkStore')
+@observer
+class EditNodeLayer extends Component<IEditNodeLayerProps> {
+
+    private renderLinks() {
+        const links = this.props.editNetworkStore!.links;
+        const isLinkView = Boolean(matchPath(navigator.getPathName(), SubSites.link));
+
+        if (isLinkView || !links) return null;
+        return links.map((link: ILink, index) => this.renderLink(link, index));
+    }
+
+    private renderLink(link: ILink, key: number) {
+        const color = TransitTypeColorHelper.getColor(link.transitType);
+        return (
+            <Polyline
+                key={key}
+                positions={link.geometry}
+                color={color}
+                weight={5}
+                opacity={0.8}
+            />
+        );
+    }
+
+    private renderNodes() {
+        const nodes = this.props.editNetworkStore!.nodes;
+        return nodes.map(n => this.renderNode(n));
+    }
+
+    private renderNode(node: INode) {
+        if (!node) return null;
+
+        return (
+            <NodeMarker
+                key={node.id}
+                isDraggable={true}
+                node={node}
+            />
+        );
+    }
+
+    render() {
+        const isNodeViewVisible = Boolean(matchPath(navigator.getPathName(), SubSites.networkNode));
+        if (!isNodeViewVisible) return null;
+
+        return (
+            <>
+                {this.renderLinks()}
+                {this.renderNodes()}
+            </>
+        );
+    }
+}
+
+export default withLeaflet(EditNodeLayer);

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -5,6 +5,7 @@ import { inject, observer } from 'mobx-react';
 import navigator from '~/routing/navigator';
 import SubSites from '~/routing/subSites';
 import { INode, ILink } from '~/models';
+import NodeLocationType from '~/types/NodeLocationType';
 import { EditNetworkStore } from '~/stores/editNetworkStore';
 import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
 import NodeMarker from '../mapIcons/NodeMarker';
@@ -51,8 +52,15 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
                 key={node.id}
                 isDraggable={true}
                 node={node}
+                onMoveMarker={this.onMoveMarker(node)}
             />
         );
+    }
+
+    private onMoveMarker = (node: INode) =>
+    (coordinatesType: NodeLocationType, coordinates: L.LatLng) => {
+        const newNode = { ...node, [coordinatesType]:coordinates };
+        this.props.editNetworkStore!.updateNode(newNode);
     }
 
     render() {

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Polyline, withLeaflet } from 'react-leaflet';
+import { Polyline } from 'react-leaflet';
 import { matchPath } from 'react-router';
 import { inject, observer } from 'mobx-react';
 import navigator from '~/routing/navigator';
@@ -8,11 +8,9 @@ import { INode, ILink } from '~/models';
 import { EditNetworkStore } from '~/stores/editNetworkStore';
 import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
 import NodeMarker from '../mapIcons/NodeMarker';
-import { LeafletContext } from '../../Map';
 
 interface IEditNodeLayerProps {
     editNetworkStore?: EditNetworkStore;
-    leaflet: LeafletContext;
 }
 
 @inject('editNetworkStore')
@@ -70,4 +68,4 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
     }
 }
 
-export default withLeaflet(EditNodeLayer);
+export default EditNodeLayer;

--- a/src/components/map/mapControls/CustomControl.tsx
+++ b/src/components/map/mapControls/CustomControl.tsx
@@ -17,10 +17,6 @@ interface IControlProps extends MapControlProps {
 }
 
 class Control extends MapControl<IControlProps>{
-    constructor(props: IControlProps) {
-        super(props);
-    }
-
     createLeafletElement({ position } : { position: any }) {
         this.leafletElement = new DivControl({ position });
         return this.leafletElement;

--- a/typings/leaflet.d.ts
+++ b/typings/leaflet.d.ts
@@ -1,0 +1,262 @@
+// Type definitions for Leaflet 1.3
+// Typings for lineStrings taken from: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/leaflet-editable/index.d.ts
+// Project: https://github.com/yohanboniface/Leaflet.Editable
+// Definitions by: Dominic Alie <https://github.com/dalie>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.9
+
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+    /**
+     * Make geometries editable in Leaflet.
+     *
+     * This is not a plug and play UI, and will not. This is a minimal, lightweight, and fully extendable API to
+     * control editing of geometries. So you can easily build your own UI with your own needs and choices.
+     */
+    interface EditableStatic {
+        new (map: Map, options: EditOptions): Editable;
+    }
+
+    /**
+     * Options to pass to L.Editable when instanciating.
+     */
+    interface EditOptions {
+        /**
+         * Class to be used when creating a new Polyline.
+         */
+        polylineClass?: object;
+
+        /**
+         * Class to be used when creating a new Polygon.
+         */
+        polygonClass?: object;
+
+        /**
+         * Class to be used when creating a new Marker.
+         */
+        markerClass?: object;
+
+        /**
+         * CSS class to be added to the map container while drawing.
+         */
+        drawingCSSClass?: string;
+
+        /**
+         * Layer used to store edit tools (vertex, line guide…).
+         */
+        // editLayer?: LayerGroup<ILayer>;
+
+        /**
+         * Default layer used to store drawn features (marker, polyline…).
+         */
+        featuresLayer?: LayerGroup<Polyline|Polygon|Marker>;
+
+        /**
+         * Class to be used as vertex, for path editing.
+         */
+        vertexMarkerClass?: object;
+
+        /**
+         * Class to be used as middle vertex, pulled by the user to create a new point in the middle of a path.
+         */
+        middleMarkerClass?: object;
+
+        /**
+         * Class to be used as Polyline editor.
+         */
+        polylineEditorClass?: object;
+
+        /**
+         * Class to be used as Polygon editor.
+         */
+        polygonEditorClass?: object;
+
+        /**
+         * Class to be used as Marker editor.
+         */
+        markerEditorClass?: object;
+
+        /**
+         * Options to be passed to the line guides.
+         */
+        lineGuideOptions?: object;
+
+        /**
+         * Set this to true if you don't want middle markers.
+         */
+        skipMiddleMarkers?: boolean;
+    }
+
+    /**
+     * Make geometries editable in Leaflet.
+     *
+     * This is not a plug and play UI, and will not. This is a minimal, lightweight, and fully extendable API to
+     * control editing of geometries. So you can easily build your own UI with your own needs and choices.
+     */
+    interface Editable {
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        options: EditOptions;
+
+        currentPolygon: Polyline|Polygon|Marker;
+
+        /**
+         * Start drawing a polyline. If latlng is given, a first point will be added. In any case, continuing on user
+         * click. If options is given, it will be passed to the polyline class constructor.
+         */
+        startPolyline(latLng?: LatLng, options?: PolylineOptions): Polyline;
+
+        /**
+         * Start drawing a polygon. If latlng is given, a first point will be added. In any case, continuing on user
+         * click. If options is given, it will be passed to the polygon class constructor.
+         */
+        startPolygon(latLng?: LatLng, options?: PolylineOptions): Polygon;
+
+        /**
+         * Start adding a marker. If latlng is given, the marker will be shown first at this point. In any case, it
+         * will follow the user mouse, and will have a final latlng on next click (or touch). If options is given,
+         * it will be passed to the marker class constructor.
+         */
+        startMarker(latLng?: LatLng, options?: MarkerOptions): Marker;
+
+        /**
+         * When you need to stop any ongoing drawing, without needing to know which editor is active.
+         */
+        stopDrawing(): void;
+
+        /**
+         * When you need to commit any ongoing drawing, without needing to know which editor is active.
+         */
+        commitDrawing(): void;
+    }
+
+    let Editable: EditableStatic;
+
+    /**
+     * EditableMixin is included to L.Polyline, L.Polygon and L.Marker. It adds the following methods to them.
+     *
+     * When editing is enabled, the editor is accessible on the instance with the editor property.
+     */
+    interface EditableMixin {
+        /**
+         * Enable editing, by creating an editor if not existing, and then calling enable on it.
+         */
+        enableEdit(): any;
+
+        /**
+         * Disable editing, also remove the editor property reference.
+         */
+        disableEdit(): void;
+
+        /**
+         * Enable or disable editing, according to current status.
+         */
+        toggleEdit(): void;
+
+        /**
+         * Return true if current instance has an editor attached, and this editor is enabled.
+         */
+        editEnabled(): boolean;
+    }
+
+    interface Map {
+        /**
+         * Whether to create a L.Editable instance at map init or not.
+         */
+        editable: boolean;
+
+        /**
+         * Options to pass to L.Editable when instanciating.
+         */
+        editOptions: EditOptions;
+
+        /**
+         * L.Editable plugin instance.
+         */
+        editTools: Editable;
+    }
+
+    // tslint:disable-next-line:no-empty-interface
+    interface Polyline extends EditableMixin {}
+
+    namespace Map {
+        interface MapOptions {
+            /**
+             * Whether to create a L.Editable instance at map init or not.
+             */
+            editable?: boolean;
+
+            /**
+             * Options to pass to L.Editable when instanciating.
+             */
+            editOptions?: EditOptions;
+        }
+    }
+
+    /**
+     * When editing a feature (marker, polyline…), an editor is attached to it. This editor basically knows
+     * how to handle the edition.
+     */
+    interface BaseEditor {
+        /**
+         * Set up the drawing tools for the feature to be editable.
+         */
+        enable(): MarkerEditor|PolylineEditor|PolygonEditor;
+
+        /**
+         * Remove editing tools.
+         */
+        disable(): MarkerEditor|PolylineEditor|PolygonEditor;
+    }
+
+    /**
+     * Inherit from L.Editable.BaseEditor.
+     * Inherited by L.Editable.PolylineEditor and L.Editable.PolygonEditor.
+     */
+    interface PathEditor extends BaseEditor {
+        /**
+         * Rebuild edit elements (vertex, middlemarker, etc.).
+         */
+        reset(): void;
+    }
+
+    /**
+     * Inherit from L.Editable.PathEditor.
+     */
+    interface PolylineEditor extends PathEditor {
+        /**
+         * Set up drawing tools to continue the line forward.
+         */
+        continueForward(): void;
+
+        /**
+         * Set up drawing tools to continue the line backward.
+         */
+        continueBackward(): void;
+    }
+
+    /**
+     * Inherit from L.Editable.PathEditor.
+     */
+    interface PolygonEditor extends PathEditor {
+        /**
+         * Set up drawing tools for creating a new hole on the polygon. If the latlng param is given, a first
+         * point is created.
+         */
+        newHole(latlng: LatLng): void;
+    }
+
+    /**
+     * Inherit from L.Editable.BaseEditor.
+     */
+    // tslint:disable-next-line:no-empty-interface
+    interface MarkerEditor extends BaseEditor {}
+
+    interface Marker extends EditableMixin, MarkerEditor {}
+
+    interface Polyline extends EditableMixin, PolylineEditor {}
+
+    interface Polygon extends EditableMixin, PolygonEditor {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5697,6 +5697,11 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leaflet-editable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet-editable/-/leaflet-editable-1.2.0.tgz#a3a01001764ba58ea923381ee6a1c814708a0b84"
+  integrity sha512-wG11JwpL8zqIbypTop6xCRGagMuWw68ihYu4uqrqc5Ep0wnEJeyob7NB2Rt5t74Oih4rwJ3OfwaGbzdowOGfYQ==
+
 "leaflet.vectorgrid@github:chriszrc/Leaflet.VectorGrid#6bdad6d07290db04ff02ebf44830b85bcfe6c020":
   version "1.3.0"
   resolved "https://codeload.github.com/chriszrc/Leaflet.VectorGrid/tar.gz/6bdad6d07290db04ff02ebf44830b85bcfe6c020"


### PR DESCRIPTION
Closes #575 
Closes #573 

* EditNetworkLayer now supports editing of single links when user is at /link/ subSite.
   * If user is at some other site, links are drawn as before (non editable). For example if current site is /node/
   * Edited link is saved on store each time user drags a vertex

Used leaflet-editable library here: https://www.npmjs.com/package/leaflet-editable
   * API: http://leaflet.github.io/Leaflet.Editable/doc/api.html