### PR TITLE
411 edit network node changes link geometry

### DIFF
--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -32,6 +32,10 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
 
     componentWillUnmount() {
         this.reactionDisposer();
+
+        const map = this.props.leaflet.map;
+        map!.off('editable:vertex:dragend');
+        map!.off('editable:vertex:deleted');
     }
 
     private removeOldLinks = () => {

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import * as L from 'leaflet';
+import _ from 'lodash';
 import { withLeaflet } from 'react-leaflet';
 import { matchPath } from 'react-router';
 import { inject, observer } from 'mobx-react';
@@ -70,7 +71,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         const map = this.props.leaflet.map;
         if (map) {
             const editableLink = L.polyline(
-                [link.geometry],
+                [_.cloneDeep(link.geometry)],
                 { interactive: false },
             ).addTo(map);
             editableLink.enableEdit();

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -82,6 +82,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
                 vertexMarker.dragging.disable();
                 vertexMarker._events.click = {};
                 vertexMarker.setOpacity(0);
+                vertexMarker.setZIndexOffset(-1000);
             });
 
             this.editableLinks.push(editableLink);

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -83,6 +83,8 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
                 vertexMarker.dragging.disable();
                 vertexMarker._events.click = {};
                 vertexMarker.setOpacity(0);
+                // Put vertex marker z-index low so that it
+                // would be below other layers that needs to be clickable
                 vertexMarker.setZIndexOffset(-1000);
             });
 

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -65,8 +65,8 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
     private drawEditableLinks = () => {
         this.removeOldLinks();
 
-        const links = this.props.nodeStore!.links;
-        links.forEach(link => this.drawEditableLink(link));
+        this.props.nodeStore!.links.forEach(
+            link => this.drawEditableLink(link));
 
         const map = this.props.leaflet.map;
 
@@ -82,7 +82,7 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
 
     private refreshEditableLink(leafletId: number) {
         const editableLink =
-        this.editableLinks.find((link: any) => link._leaflet_id === leafletId);
+            this.editableLinks.find((link: any) => link._leaflet_id === leafletId);
         const latlngs = editableLink!.getLatLngs()[0] as L.LatLng[];
         const editableLinkIndex =
             this.editableLinks.findIndex((link: any) => link._leaflet_id === leafletId);
@@ -112,6 +112,8 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
                 vertexMarker.dragging.disable();
                 vertexMarker._events.click = {};
                 vertexMarker.setOpacity(0);
+                // Put vertex marker z-index low so that it
+                // would be below other layers that needs to be clickable
                 vertexMarker.setZIndexOffset(-1000);
             });
             this.editableLinks.push(editableLink);

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -111,6 +111,7 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
                 vertexMarker.dragging.disable();
                 vertexMarker._events.click = {};
                 vertexMarker.setOpacity(0);
+                vertexMarker.setZIndexOffset(-1000);
             });
             this.editableLinks.push(editableLink);
         }

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import * as L from 'leaflet';
+import _ from 'lodash';
 import { withLeaflet } from 'react-leaflet';
 import { matchPath } from 'react-router';
 import { inject, observer } from 'mobx-react';
@@ -99,7 +100,7 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
         const map = this.props.leaflet.map;
         if (map) {
             const editableLink = L.polyline(
-                [link.geometry],
+                [_.cloneDeep(link.geometry)],
                 { interactive: false },
             ).addTo(map);
             editableLink.enableEdit();

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -1,41 +1,45 @@
 import React, { Component } from 'react';
-import { Polyline } from 'react-leaflet';
+import * as L from 'leaflet';
+import { withLeaflet } from 'react-leaflet';
 import { matchPath } from 'react-router';
 import { inject, observer } from 'mobx-react';
+import { IReactionDisposer, reaction } from 'mobx';
 import navigator from '~/routing/navigator';
 import SubSites from '~/routing/subSites';
-import { INode, ILink } from '~/models';
+import { ILink } from '~/models';
 import NodeLocationType from '~/types/NodeLocationType';
 import { NodeStore } from '~/stores/nodeStore';
-import TransitTypeColorHelper from '~/util/transitTypeColorHelper';
 import NodeMarker from '../mapIcons/NodeMarker';
+import { LeafletContext } from '../../Map';
 
 interface IEditNodeLayerProps {
     nodeStore?: NodeStore;
+    leaflet: LeafletContext;
 }
 
 @inject('nodeStore')
 @observer
 class EditNodeLayer extends Component<IEditNodeLayerProps> {
-    private renderLinks() {
-        const links = this.props.nodeStore!.links;
-        const isLinkView = Boolean(matchPath(navigator.getPathName(), SubSites.link));
+    private reactionDisposer: IReactionDisposer;
+    private editableLinks: L.Polyline[] = [];
 
-        if (isLinkView || !links) return null;
-        return links.map((link: ILink, index) => this.renderLink(link, index));
+    componentDidMount() {
+        this.reactionDisposer = reaction(
+            () => this.props.nodeStore!.node,
+            () => this.props.nodeStore!.node === null && this.removeOldLinks(),
+        );
     }
 
-    private renderLink(link: ILink, key: number) {
-        const color = TransitTypeColorHelper.getColor(link.transitType);
-        return (
-            <Polyline
-                key={key}
-                positions={link.geometry}
-                color={color}
-                weight={5}
-                opacity={0.8}
-            />
-        );
+    componentWillUnmount() {
+        this.reactionDisposer();
+    }
+
+    private removeOldLinks = () => {
+        // Remove (possible) previously drawn links from map
+        this.editableLinks.forEach((editableLink: any) => {
+            editableLink.remove();
+        });
+        this.editableLinks = [];
     }
 
     private renderNode() {
@@ -47,27 +51,85 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
                 key={node.id}
                 isDraggable={true}
                 node={node}
-                onMoveMarker={this.onMoveMarker(node)}
+                onMoveMarker={this.onMoveMarker()}
             />
         );
     }
 
-    private onMoveMarker = (node: INode) =>
+    private onMoveMarker = () =>
         (coordinatesType: NodeLocationType, coordinates: L.LatLng) => {
             this.props.nodeStore!.updateNode(coordinatesType, coordinates);
         }
+
+    private drawEditableLinks = () => {
+        this.removeOldLinks();
+
+        const links = this.props.nodeStore!.links;
+        links.forEach(link => this.drawEditableLink(link));
+
+        const map = this.props.leaflet.map;
+
+        map!.off('editable:vertex:dragend');
+        map!.on('editable:vertex:dragend', (data: any) => {
+            this.refreshEditableLink(data.layer._leaflet_id);
+        });
+        map!.off('editable:vertex:deleted');
+        map!.on('editable:vertex:deleted', (data: any) => {
+            this.refreshEditableLink(data.layer._leaflet_id);
+        });
+    }
+
+    private refreshEditableLink(leafletId: number) {
+        const editableLink =
+        this.editableLinks.find((link: any) => link._leaflet_id === leafletId);
+        const latlngs = editableLink!.getLatLngs()[0] as L.LatLng[];
+        const editableLinkIndex =
+            this.editableLinks.findIndex((link: any) => link._leaflet_id === leafletId);
+        this.props.nodeStore!.changeLinkGeometry(latlngs, editableLinkIndex);
+    }
+
+    private drawEditableLink = (link: ILink) => {
+        const isNodeView = Boolean(matchPath(navigator.getPathName(), SubSites.node));
+        if (!isNodeView || !link) return;
+
+        this.drawEditableLinkToMap(link);
+    }
+
+    private drawEditableLinkToMap = (link: ILink) => {
+        const map = this.props.leaflet.map;
+        if (map) {
+            const editableLink = L.polyline(
+                [link.geometry],
+                {
+                    bubblingMouseEvents: true,
+                    interactive: false,
+                },
+            ).addTo(map);
+            editableLink.enableEdit();
+            const latLngs = editableLink.getLatLngs() as L.LatLng[][];
+            const coords = latLngs[0];
+            const coordsToDisable = [coords[0], coords[coords.length - 1]];
+            coordsToDisable.forEach((coordToDisable: any) => {
+                const vertexMarker = coordToDisable.__vertex;
+                vertexMarker.dragging.disable();
+                vertexMarker._events.click = {};
+                vertexMarker.setOpacity(0);
+            });
+            this.editableLinks.push(editableLink);
+        }
+    }
 
     render() {
         const isNodeViewVisible = Boolean(matchPath(navigator.getPathName(), SubSites.node));
         if (!isNodeViewVisible) return null;
 
+        this.drawEditableLinks();
         return (
             <>
-                {this.renderLinks()}
                 {this.renderNode()}
             </>
         );
     }
 }
 
-export default EditNodeLayer;
+export default withLeaflet(EditNodeLayer);

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -100,10 +100,7 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
         if (map) {
             const editableLink = L.polyline(
                 [link.geometry],
-                {
-                    bubblingMouseEvents: true,
-                    interactive: false,
-                },
+                { interactive: false },
             ).addTo(map);
             editableLink.enableEdit();
             const latLngs = editableLink.getLatLngs() as L.LatLng[][];

--- a/src/components/map/layers/edit/EditNodeLayer.tsx
+++ b/src/components/map/layers/edit/EditNodeLayer.tsx
@@ -33,6 +33,10 @@ class EditNodeLayer extends Component<IEditNodeLayerProps> {
 
     componentWillUnmount() {
         this.reactionDisposer();
+
+        const map = this.props.leaflet.map;
+        map!.off('editable:vertex:dragend');
+        map!.off('editable:vertex:deleted');
     }
 
     private removeOldLinks = () => {

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -21,6 +21,11 @@ export class LinkStore {
     }
 
     @action
+    public changeLinkGeometry = (latLngs: L.LatLng[]) => {
+        this._link!.geometry = latLngs;
+    }
+
+    @action
     public setLink = (link: ILink) => {
         this._link = link;
     }

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -27,6 +27,11 @@ export class NodeStore {
     }
 
     @action
+    public changeLinkGeometry = (latLngs: L.LatLng[], index: number) => {
+        this._links[index].geometry = latLngs;
+    }
+
+    @action
     public setLinks = (links: ILink[]) => {
         this._links = links;
     }
@@ -49,10 +54,19 @@ export class NodeStore {
             [property]: value,
         };
 
-        if (
-            this._node.type === NodeType.STOP &&
-            !this._node.stop
-        ) {
+        const links = this._links;
+        // Update the first link geometry of startNodes to coordinatesProjection
+        links
+            .filter(link => link.startNode.id === this._node!.id)
+            .map(link => link.geometry[0] = this._node!.coordinatesProjection);
+        // Update the last link geometry of endNodes to coordinatesProjection
+        links
+            .filter(link => link.endNode.id === this._node!.id)
+            .map(link => link.geometry[link.geometry.length - 1]
+                = this._node!.coordinatesProjection);
+        this.setLinks(links);
+
+        if (this._node.type === NodeType.STOP && !this._node.stop) {
             this._node.stop = StopFactory.createNewStop();
         }
     }


### PR DESCRIPTION
Closes #411

* Fixed & refactored editLinkLayer as well a bit as I found bugs etc:
   * invisible edgePoint prevented coordinatesMarker click
   * removing edgePoint didn't update linkStore
* Using react leaflet with Leaflet.Editable isn't as easy as one would expect --> using just leaflet instead