### PR TITLE
677 route path geometry should be required

### DIFF
--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -162,12 +162,12 @@ export class RoutePathStore {
         };
         this._undoStore.addItem(currentUndoState);
 
-        this.setOldRoutePath(_.cloneDeep(this._routePath));
+        this.setOldRoutePath(this._routePath);
     }
 
     @action
     public setOldRoutePath = (routePath: IRoutePath) => {
-        this._oldRoutePath = routePath;
+        this._oldRoutePath = _.cloneDeep(routePath);
     }
 
     @action

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -164,7 +164,7 @@ export class RoutePathStore {
         this._undoStore.addItem(currentUndoState);
         this._isGeometryValid = validateRoutePathLinks(routePathLinks);
 
-        this.setOldRoutePath(routePath);
+        this.setOldRoutePath(this._routePath);
     }
 
     @action

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -23,7 +23,6 @@ export interface UndoState {
 export class RoutePathStore {
     @observable private _routePath: IRoutePath|null;
     @observable private _oldRoutePath: IRoutePath|null;
-    @observable private _isGeometryValid: boolean;
     @observable private _neighborRoutePathLinks: IRoutePathLink[];
     @observable private _neighborToAddType: NeighborToAddType;
     @observable private _highlightedMapItem: string | null;
@@ -36,7 +35,6 @@ export class RoutePathStore {
         this._neighborRoutePathLinks = [];
         this._highlightedMapItem = null;
         this._extendedListItems = [];
-        this._isGeometryValid = true;
         this._activeTab = RoutePathViewTab.Info;
         this._undoStore = new UndoStore();
     }
@@ -57,13 +55,15 @@ export class RoutePathStore {
     }
 
     @computed
-    get isGeometryValid() {
-        return this._isGeometryValid;
+    get isDirty() {
+        return !_.isEqual(this._routePath, this._oldRoutePath);
     }
 
     @computed
-    get isDirty() {
-        return !_.isEqual(this._routePath, this._oldRoutePath);
+    get isGeometryValid() {
+        return validateRoutePathLinks(
+            this._routePath!.routePathLinks!,
+        );
     }
 
     @computed
@@ -118,7 +118,6 @@ export class RoutePathStore {
     @action
     public onRoutePathLinksChanged() {
         this.recalculateOrderNumbers();
-        this.validateRoutePathGeometry();
     }
 
     @action
@@ -162,9 +161,8 @@ export class RoutePathStore {
             routePathLinks,
         };
         this._undoStore.addItem(currentUndoState);
-        this._isGeometryValid = validateRoutePathLinks(routePathLinks);
 
-        this.setOldRoutePath(this._routePath);
+        this.setOldRoutePath(_.cloneDeep(this._routePath));
     }
 
     @action
@@ -199,7 +197,6 @@ export class RoutePathStore {
             routePathLink);
 
         this.recalculateOrderNumbers();
-
         this.resetUndoState();
     }
 
@@ -211,7 +208,6 @@ export class RoutePathStore {
         this._routePath!.routePathLinks!.splice(linkToRemoveIndex, 1);
 
         this.recalculateOrderNumbers();
-
         this.resetUndoState();
     }
 
@@ -219,7 +215,6 @@ export class RoutePathStore {
     public setRoutePathLinks = (routePathLinks: IRoutePathLink[]) => {
         this._routePath!.routePathLinks = routePathLinks;
         this.recalculateOrderNumbers();
-
         this.sortRoutePathLinks();
     }
 
@@ -274,12 +269,6 @@ export class RoutePathStore {
             // Order numbers start from 1
             rpLink.orderNumber = index + 1;
         });
-    }
-
-    private validateRoutePathGeometry = () => {
-        this._isGeometryValid = validateRoutePathLinks(
-            this._routePath!.routePathLinks!,
-        );
     }
 }
 

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -162,6 +162,7 @@ export class RoutePathStore {
             routePathLinks,
         };
         this._undoStore.addItem(currentUndoState);
+        this._isGeometryValid = validateRoutePathLinks(routePathLinks);
 
         this.setOldRoutePath(routePath);
     }

--- a/src/util/geomValidator.ts
+++ b/src/util/geomValidator.ts
@@ -1,6 +1,7 @@
 import { IRoutePathLink } from '~/models';
 
 const validateRoutePathLinks = (rpLinks: IRoutePathLink[]) => {
+    if (rpLinks.length === 0) return false;
     return rpLinks.every((rpLink, index) => (
         index === 0 || rpLinks[index - 1].endNode.id === rpLink.startNode.id));
 };


### PR DESCRIPTION
Closes #677 

Test by:
- Creating new routepath, it will not be able to save before geometry is no longer empty
- Open old routepath, unable to save if removing all routepath links
Bonus:
- Fixed bug that was alerting that routepath has changes due to initial reorganizing of ordernumbers