### PR TITLE
Fixed input container: moved validation to ViewFormBase

### DIFF
--- a/src/components/map/tools/AddNetworkNodeTool.ts
+++ b/src/components/map/tools/AddNetworkNodeTool.ts
@@ -26,10 +26,10 @@ class AddNetworkNodeTool implements BaseTool {
     }
     private onMapClick = async (clickEvent: CustomEvent) => {
         ToolbarStore.selectTool(null);
-        navigator.goTo(SubSites.newNode);
         RoutePathStore.clear();
         const newNode = NodeFactory.createNewNode(clickEvent.detail.latlng);
         NodeStore.init(newNode, []);
+        navigator.goTo(SubSites.newNode);
     }
 }
 

--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -1,4 +1,5 @@
 import { Component } from 'react';
+import FormValidator, { IValidationResult } from '~/validation/FormValidator';
 
 interface IViewFormBaseState {
     isLoading: boolean;
@@ -9,12 +10,35 @@ interface IViewFormBaseState {
 class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Props, State> {
     protected isFormValid = () => {
         return !Object.values(this.state.invalidPropertiesMap)
-            .some(fieldIsValid => !fieldIsValid);
+            .some(validatorResult => !validatorResult.isValid);
     }
 
-    protected markInvalidProperties = (property: string, isValid: boolean) => {
+    protected validateAllProperties = (validationModel: object, validationEntity: any) => {
+        this.setState({
+            invalidPropertiesMap: {},
+        });
+
+        for (const property of Object.keys(validationModel)) {
+            this.validateProperty(
+                validationModel,
+                property,
+                validationEntity[property],
+            );
+        }
+    }
+
+    protected validateProperty = (validationModel: object, property: string, value: any) => {
+        const validatorRule = validationModel[property];
+        if (!validatorRule) return;
+
+        const validatorResult: IValidationResult
+            = FormValidator.validate(value, validatorRule);
+        this.markInvalidProperties(property, validatorResult);
+    }
+
+    protected markInvalidProperties = (property: string, validatorResult: IValidationResult) => {
         const invalidPropertiesMap = this.state.invalidPropertiesMap;
-        invalidPropertiesMap[property] = isValid;
+        invalidPropertiesMap[property] = validatorResult;
         this.setState({
             invalidPropertiesMap,
         });

--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -18,17 +18,16 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Pr
             invalidPropertiesMap: {},
         });
 
-        for (const property of Object.keys(validationModel)) {
+        Object.entries(validationModel).forEach(([property, validatorRule]) => {
             this.validateProperty(
-                validationModel,
+                validatorRule,
                 property,
                 validationEntity[property],
             );
-        }
+        });
     }
 
-    protected validateProperty = (validationModel: object, property: string, value: any) => {
-        const validatorRule = validationModel[property];
+    protected validateProperty = (validatorRule: string, property: string, value: any) => {
         if (!validatorRule) return;
 
         const validatorResult: IValidationResult

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -186,7 +186,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
     private onChange = (property: string) => (value: any) => {
         this.props.linkStore!.updateLinkProperty(property, value);
-        this.validateProperty(linkValidationModel, property, value);
+        this.validateProperty(linkValidationModel[property], property, value);
     }
 
     render() {

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -7,7 +7,6 @@ import L from 'leaflet';
 import { FiChevronRight, FiChevronLeft } from 'react-icons/fi';
 import ButtonType from '~/enums/buttonType';
 import TransitType from '~/enums/transitType';
-import { IValidationResult } from '~/validation/FormValidator';
 import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import Loader from '~/components/shared/loader/Loader';
 import LinkService from '~/services/linkService';
@@ -70,6 +69,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         if (this.props.linkStore!.link) {
             const bounds = L.latLngBounds(this.props.linkStore!.link!.geometry);
             this.props.mapStore!.setMapBounds(bounds);
+            this.validateAllProperties(linkValidationModel, this.props.linkStore!.link);
         }
     }
 
@@ -125,14 +125,6 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
         this.setState({ isLoading: false });
     }
-
-    private onChange = (property: string) =>
-        (value: any, validationResult?: IValidationResult) => {
-            this.props.linkStore!.updateLinkProperty(property, value);
-            if (validationResult) {
-                this.markInvalidProperties(property, validationResult!.isValid);
-            }
-        }
 
     private save = async () => {
         this.setState({ isLoading: true });
@@ -192,8 +184,14 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         return this.props.linkStore!.existingTransitTypes.includes(transitType);
     }
 
+    private onChange = (property: string) => (value: any) => {
+        this.props.linkStore!.updateLinkProperty(property, value);
+        this.validateProperty(linkValidationModel, property, value);
+    }
+
     render() {
         const link = this.props.linkStore!.link;
+        const invalidPropertiesMap = this.state.invalidPropertiesMap;
         if (this.state.isLoading) {
             return (
                 <div className={classnames(s.linkView, s.loaderContainer)}>
@@ -280,16 +278,16 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                             disabled={isEditingDisabled}
                             value={link.osNumber}
                             type='number'
+                            validationResult={invalidPropertiesMap['osNumber']}
                             onChange={this.onChange('osNumber')}
-                            validatorRule={linkValidationModel.osNumber}
                         />
                         <InputContainer
                             label='LINKIN PITUUS (m)'
                             disabled={isEditingDisabled}
                             value={link.length}
                             type='number'
+                            validationResult={invalidPropertiesMap['length']}
                             onChange={this.onChange('length')}
-                            validatorRule={linkValidationModel.length}
                         />
                     </div>
                     <div className={s.flexRow}>
@@ -297,6 +295,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                             label='KATU'
                             disabled={isEditingDisabled}
                             value={link.streetName}
+                            validationResult={invalidPropertiesMap['streetName']}
                             onChange={this.onChange('streetName')}
                         />
                         <InputContainer
@@ -304,8 +303,8 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                             disabled={isEditingDisabled}
                             value={link.streetNumber}
                             type='number'
+                            validationResult={invalidPropertiesMap['streetNumber']}
                             onChange={this.onChange('streetNumber')}
-                            validatorRule={linkValidationModel.streetNumber}
                         />
                         <Dropdown
                             onChange={this.onChange('municipalityCode')}

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -6,7 +6,7 @@ import { INode } from '~/models';
 import { DialogStore } from '~/stores/dialogStore';
 import { NodeStore } from '~/stores/nodeStore';
 import { MapStore } from '~/stores/mapStore';
-import stopValidatorModel from '~/validation/models/stopValidatorModel';
+import stopValidationModel from '~/validation/models/stopValidationModel';
 import LinkService from '~/services/linkService';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
@@ -140,7 +140,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
     private _validateAllProperties = (nodeType: NodeType) => {
         const node = this.props.nodeStore!.node;
         if (nodeType === NodeType.STOP) {
-            this.validateAllProperties(stopValidatorModel, node.stop);
+            this.validateAllProperties(stopValidationModel, node.stop);
         } else {
             this.validateAllProperties({}, node);
         }
@@ -163,7 +163,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private onStopPropertyChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateStop(property, value);
-        this.validateProperty(stopValidatorModel[property], property, value);
+        this.validateProperty(stopValidationModel[property], property, value);
     }
 
     render() {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -148,12 +148,12 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private onNodeGeometryChange = (property: NodeLocationType) => (value: any) => {
         this.props.nodeStore!.updateNodeGeometry(property, value);
-        this.validateProperty({}, property, value);
+        this.validateProperty('', property, value);
     }
 
     private onNodePropertiesChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateNode(property, value);
-        this.validateProperty({}, property, value);
+        this.validateProperty('', property, value);
         if (property === 'type') {
             this._validateAllProperties(value);
         }
@@ -161,7 +161,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private onStopPropertiesChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateStop(property, value);
-        this.validateProperty(stopValidatorModel, property, value);
+        this.validateProperty(stopValidatorModel[property], property, value);
     }
 
     render() {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -152,7 +152,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         this.validateProperty('', property, value);
     }
 
-    private onNodePropertiesChange = (property: string) => (value: any) => {
+    private onNodePropertyChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateNode(property, value);
         // TODO: add nodeValidationModel. Move stop's invalidPropertiesMap into stopFrom?
         this.validateProperty('', property, value);
@@ -161,7 +161,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         }
     }
 
-    private onStopPropertiesChange = (property: string) => (value: any) => {
+    private onStopPropertyChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateStop(property, value);
         this.validateProperty(stopValidatorModel[property], property, value);
     }
@@ -203,12 +203,12 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
                                     label='LYHYT ID'
                                     disabled={isEditingDisabled}
                                     value={node.shortId}
-                                    onChange={this.onNodePropertiesChange('shortId')}
+                                    onChange={this.onNodePropertyChange('shortId')}
                                     validationResult={invalidPropertiesMap['length']}
                                 />
                                 <Dropdown
                                     label='TYYPPI'
-                                    onChange={this.onNodePropertiesChange('type')}
+                                    onChange={this.onNodePropertyChange('type')}
                                     disabled={isEditingDisabled}
                                     selected={node.type}
                                     codeList={nodeTypeCodeList}
@@ -226,7 +226,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
                             <StopForm
                                 isEditingDisabled={isEditingDisabled}
                                 stop={node.stop!}
-                                onChange={this.onStopPropertiesChange}
+                                onChange={this.onStopPropertyChange}
                                 invalidPropertiesMap={invalidPropertiesMap}
                             />
                         }

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -148,11 +148,13 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private onNodeGeometryChange = (property: NodeLocationType) => (value: any) => {
         this.props.nodeStore!.updateNodeGeometry(property, value);
+        // TODO: add nodeValidationModel. Move stop's invalidPropertiesMap into stopFrom?
         this.validateProperty('', property, value);
     }
 
     private onNodePropertiesChange = (property: string) => (value: any) => {
         this.props.nodeStore!.updateNode(property, value);
+        // TODO: add nodeValidationModel. Move stop's invalidPropertiesMap into stopFrom?
         this.validateProperty('', property, value);
         if (property === 'type') {
             this._validateAllProperties(value);

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -9,7 +9,7 @@ import * as s from './stopForm.scss';
 interface IStopFormProps {
     stop: IStop;
     isEditingDisabled: boolean;
-    onChange: Function;
+    onChange: (property: string) => (value: any) => void;
     invalidPropertiesMap: object;
 }
 

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import InputContainer from '~/components/sidebar/InputContainer';
 import { IStop } from '~/models';
-import stopValidationModel from '~/validation/models/stopValidationModel';
-import { IValidationResult } from '~/validation/FormValidator';
 import municipalityCodeList from '~/codeLists/municipalityCodeList';
 import { Dropdown } from '~/components/controls';
 import SidebarHeader from '../SidebarHeader';
@@ -10,11 +8,12 @@ import * as s from './stopForm.scss';
 
 interface IStopFormProps {
     stop: IStop;
-    onChange: (property: string) => (value: any, validationResult?: IValidationResult) => void;
     isEditingDisabled: boolean;
+    onChange: Function;
+    invalidPropertiesMap: object;
 }
 
-const stopForm = ({ stop, isEditingDisabled, onChange }: IStopFormProps) => {
+const stopForm = ({ stop, isEditingDisabled, onChange, invalidPropertiesMap }: IStopFormProps) => {
     return (
         <div className={s.stopView}>
             <SidebarHeader
@@ -32,14 +31,14 @@ const stopForm = ({ stop, isEditingDisabled, onChange }: IStopFormProps) => {
                         disabled={isEditingDisabled}
                         value={stop.nameFi}
                         onChange={onChange('nameFi')}
-                        validatorRule={stopValidationModel.name}
+                        validationResult={invalidPropertiesMap['nameFi']}
                     />
                     <InputContainer
                         label='NIMI RUOTSIKSI'
                         disabled={isEditingDisabled}
                         value={stop.nameSe}
                         onChange={onChange('nameSe')}
-                        validatorRule={stopValidationModel.name}
+                        validationResult={invalidPropertiesMap['nameSe']}
                     />
                 </div>
                 <div className={s.flexRow}>
@@ -142,9 +141,9 @@ const stopForm = ({ stop, isEditingDisabled, onChange }: IStopFormProps) => {
                         label='SÄDE (m)'
                         disabled={isEditingDisabled}
                         value={stop.radius}
-                        onChange={onChange('radius')}
                         type='number'
-                        validatorRule={stopValidationModel.radius}
+                        onChange={onChange('radius')}
+                        validationResult={invalidPropertiesMap['radius']}
                     />
                     <InputContainer
                         label='SUUNTA'

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -13,6 +13,7 @@ import { NetworkStore, NodeSize, MapLayer } from '~/stores/networkStore';
 import { ToolbarStore } from '~/stores/toolbarStore';
 import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import DialogStore from '~/stores/dialogStore';
+import routePathValidationModel from '~/validation/models/routePathValidationModel';
 import RouteService from '~/services/routeService';
 import RoutePathService from '~/services/routePathService';
 import LineService from '~/services/lineService';
@@ -26,12 +27,6 @@ import RoutePathTabs from './RoutePathTabs';
 import RoutePathHeader from './RoutePathHeader';
 import * as s from './routePathView.scss';
 
-interface IRoutePathViewState {
-    isLoading: boolean;
-    invalidPropertiesMap: object;
-    isEditingDisabled: boolean;
-}
-
 interface IRoutePathViewProps {
     errorStore?: ErrorStore;
     routePathStore?: RoutePathStore;
@@ -39,6 +34,12 @@ interface IRoutePathViewProps {
     toolbarStore?: ToolbarStore;
     match?: match<any>;
     isNewRoutePath: boolean;
+}
+
+interface IRoutePathViewState {
+    isLoading: boolean;
+    invalidPropertiesMap: object;
+    isEditingDisabled: boolean;
 }
 
 @inject('routePathStore', 'networkStore', 'toolbarStore', 'errorStore')
@@ -80,6 +81,8 @@ class RoutePathView extends ViewFormBase<IRoutePathViewProps, IRoutePathViewStat
                 this.props.routePathStore!.onRoutePathLinksChanged();
             },
         );
+        this.validateAllProperties(routePathValidationModel, this.props.routePathStore!.routePath);
+
         this.setState({
             isLoading: false,
         });
@@ -140,14 +143,20 @@ class RoutePathView extends ViewFormBase<IRoutePathViewProps, IRoutePathViewStat
         }
     }
 
+    private onChange = (property: string) => (value: any) => {
+        this.props.routePathStore!.updateRoutePathProperty(property, value);
+        this.validateProperty(routePathValidationModel, property, value);
+    }
+
     public renderTabContent = () => {
         if (this.props.routePathStore!.activeTab === RoutePathViewTab.Info) {
             return (
                 <RoutePathInfoTab
                     isEditingDisabled={this.state.isEditingDisabled}
                     routePath={this.props.routePathStore!.routePath!}
-                    markInvalidProperties={this.markInvalidProperties}
                     isNewRoutePath={this.props.isNewRoutePath}
+                    onChange={this.onChange}
+                    invalidPropertiesMap={this.state.invalidPropertiesMap}
                 />
             );
         }

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -145,7 +145,7 @@ class RoutePathView extends ViewFormBase<IRoutePathViewProps, IRoutePathViewStat
 
     private onChange = (property: string) => (value: any) => {
         this.props.routePathStore!.updateRoutePathProperty(property, value);
-        this.validateProperty(routePathValidationModel, property, value);
+        this.validateProperty(routePathValidationModel[property], property, value);
     }
 
     public renderTabContent = () => {

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathForm.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathForm.tsx
@@ -9,7 +9,6 @@ import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
 import routePathValidationModel from '~/validation/models/routePathValidationModel';
-import { IValidationResult } from '~/validation/FormValidator';
 import InputContainer from '../../InputContainer';
 import TextContainer from '../../TextContainer';
 import LinkListView from './LinkListView';
@@ -22,20 +21,13 @@ interface IRoutePathFormProps {
     isEditingDisabled: boolean;
     routePath: IRoutePath;
     isNewRoutePath: boolean;
-    markInvalidProperties: (property: string, isValid: boolean) => void;
+    onChange: Function;
+    invalidPropertiesMap: object;
 }
 
 @inject('routePathStore')
 @observer
 class RoutePathForm extends React.Component<IRoutePathFormProps>{
-    private onChange = (property: string) =>
-        (value: any, validationResult?: IValidationResult) => {
-            this.props.routePathStore!.updateRoutePathProperty(property, value);
-            if (validationResult) {
-                this.props.markInvalidProperties(property, validationResult.isValid);
-            }
-        }
-
     private redirectToNewRoutePathView = () => {
         const routePath = this.props.routePathStore!.routePath;
         if (!routePath) return;
@@ -77,6 +69,8 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
     render() {
         const isEditingDisabled = this.props.isEditingDisabled;
         const disabledIfUpdating = !this.props.isNewRoutePath || this.props.isEditingDisabled;
+        const invalidPropertiesMap = this.props.invalidPropertiesMap;
+        const onChange = this.props.onChange;
 
         const routePath = this.props.routePath;
         return (
@@ -97,15 +91,15 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                         label='LÄHTÖPAIKKA SUOMEKSI'
                         disabled={isEditingDisabled}
                         value={routePath.originFi}
-                        onChange={this.onChange('originFi')}
-                        validatorRule={routePathValidationModel.origin}
+                        onChange={onChange('originFi')}
+                        validationResult={invalidPropertiesMap['originFi']}
                     />
                     <InputContainer
                         label='PÄÄTEPAIKKA SUOMEKSI'
                         disabled={isEditingDisabled}
                         value={routePath.destinationFi}
-                        onChange={this.onChange('destinationFi')}
-                        validatorRule={routePathValidationModel.destination}
+                        onChange={onChange('destinationFi')}
+                        validationResult={invalidPropertiesMap['destinationFi']}
                     />
                 </div>
                 <div className={s.flexRow}>
@@ -113,15 +107,15 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                         label='LÄHTÖPAIKKA RUOTSIKSI'
                         disabled={isEditingDisabled}
                         value={routePath.originSw}
-                        onChange={this.onChange('originSw')}
-                        validatorRule={routePathValidationModel.origin}
+                        onChange={onChange('originSw')}
+                        validationResult={invalidPropertiesMap['originSw']}
                     />
                     <InputContainer
                         label='PÄÄTEPAIKKA RUOTSIKSI'
                         disabled={isEditingDisabled}
                         value={routePath.destinationSw}
-                        onChange={this.onChange('destinationSw')}
-                        validatorRule={routePathValidationModel.destination}
+                        onChange={onChange('destinationSw')}
+                        validationResult={invalidPropertiesMap['destinationSw']}
                     />
                 </div>
                 <div className={s.flexRow}>
@@ -129,33 +123,33 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                         label='LYHENNE SUOMEKSI'
                         disabled={isEditingDisabled}
                         value={routePath.routePathShortName}
-                        onChange={this.onChange('routePathShortName')}
-                        validatorRule={routePathValidationModel.shortName}
+                        onChange={onChange('routePathShortName')}
+                        validationResult={invalidPropertiesMap['routePathShortName']}
                     />
                     <InputContainer
                         label='LYHENNE RUOTSIKSI'
                         disabled={isEditingDisabled}
                         value={routePath.routePathShortNameSw}
-                        onChange={this.onChange('routePathShortNameSw')}
-                        validatorRule={routePathValidationModel.shortName}
+                        onChange={onChange('routePathShortNameSw')}
+                        validationResult={invalidPropertiesMap['routePathShortNameSw']}
                     />
                 </div>
                 <div className={s.flexRow}>
                     <InputContainer
                         label='VOIM. AST'
+                        disabled={disabledIfUpdating}
                         type='date'
                         value={routePath.startTime}
-                        onChange={this.onChange('startTime')}
-                        disabled={disabledIfUpdating}
-                        validatorRule={routePathValidationModel.date}
+                        onChange={onChange('startTime')}
+                        validationResult={invalidPropertiesMap['startTime']}
                     />
                     <InputContainer
                         label='VIIM.VOIM.OLO'
+                        disabled={this.props.isEditingDisabled}
                         type='date'
                         value={routePath.endTime}
-                        onChange={this.onChange('endTime')}
-                        disabled={this.props.isEditingDisabled}
-                        validatorRule={routePathValidationModel.date}
+                        onChange={onChange('endTime')}
+                        validationResult={invalidPropertiesMap['endTime']}
                     />
                     <InputContainer
                         label={this.renderLengthLabel()}
@@ -163,7 +157,8 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                         disabled={isEditingDisabled}
                         validatorRule={routePathValidationModel.length}
                         type='number'
-                        onChange={this.onChange('length')}
+                        onChange={onChange('length')}
+                        validationResult={invalidPropertiesMap['length']}
                     />
                     <TextContainer
                         label='Laskettu'
@@ -174,15 +169,15 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                     <Dropdown
                         label='SUUNTA'
                         disabled={disabledIfUpdating}
-                        onChange={this.onChange('direction')}
                         items={['1', '2']}
                         selected={this.props.routePath.direction}
+                        onChange={onChange('direction')}
                     />
                     <Dropdown
                         label='POIKKEUSREITTI'
                         disabled={isEditingDisabled}
                         selected={this.props.routePath.exceptionPath}
-                        onChange={this.onChange('exceptionPath')}
+                        onChange={onChange('exceptionPath')}
                         codeList={booleanCodeList}
                     />
                 </div>
@@ -235,14 +230,14 @@ class RoutePathForm extends React.Component<IRoutePathFormProps>{
                     <div className={s.flexInnerRow}>
                         {/* TODO */}
                         <Dropdown
-                            onChange={this.onChange}
+                            onChange={onChange('foo')}
                             disabled={isEditingDisabled}
                             items={['Suunta 1']}
                             selected='Suunta 1'
                         />
                         {/* TODO */}
                         <Dropdown
-                            onChange={this.onChange}
+                            onChange={onChange('foo')}
                             disabled={isEditingDisabled}
                             items={['Suunta 2']}
                             selected='Suunta 2'

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathForm.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathForm.tsx
@@ -21,7 +21,7 @@ interface IRoutePathFormProps {
     isEditingDisabled: boolean;
     routePath: IRoutePath;
     isNewRoutePath: boolean;
-    onChange: Function;
+    onChange: (property: string) => (value: any) => void;
     invalidPropertiesMap: object;
 }
 

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
@@ -14,8 +14,9 @@ interface IRoutePathInfoTabProps {
     isEditingDisabled: boolean;
     routePathStore?: RoutePathStore;
     routePath: IRoutePath;
-    markInvalidProperties: (property: string, isValid: boolean) => void;
     isNewRoutePath: boolean;
+    onChange: Function;
+    invalidPropertiesMap: object;
 }
 
 @inject('routePathStore')
@@ -37,10 +38,11 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
             <div className={s.content}>
                 <div className={s.formSection}>
                     <RoutePathForm
-                        markInvalidProperties={this.props.markInvalidProperties}
                         isEditingDisabled={this.props.isEditingDisabled}
                         routePath={this.props.routePathStore!.routePath!}
                         isNewRoutePath={this.props.isNewRoutePath}
+                        onChange={this.props.onChange}
+                        invalidPropertiesMap={this.props.invalidPropertiesMap}
                     />
                 </div>
             </div>

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
@@ -15,7 +15,7 @@ interface IRoutePathInfoTabProps {
     routePathStore?: RoutePathStore;
     routePath: IRoutePath;
     isNewRoutePath: boolean;
-    onChange: Function;
+    onChange: (property: string) => (value: any) => void;
     invalidPropertiesMap: object;
 }
 

--- a/src/models/IStop.ts
+++ b/src/models/IStop.ts
@@ -2,7 +2,7 @@ export default interface IStop {
     nodeId: string;
     municipality: string;
     nameFi: string;
-    nameSe: string;
+    nameSe: string; // TODO: rename as nameSw
     placeNameFi: string;
     placeNameSe: string;
     addressFi: string;

--- a/src/validation/models/linkValidationModel.ts
+++ b/src/validation/models/linkValidationModel.ts
@@ -1,7 +1,8 @@
 const linkValidationModel = {
-    osNumber: 'required|numeric|min:0|max:99999', // TODO: These are just made up
-    streetNumber: 'required|numeric|min:0|max:99999', // TODO: These are just made up
-    length: 'required|numeric|min:0|max:99999', // TODO: These are just made up
+    osNumber: 'required|min:0|max:99999|numeric', // TODO: These are just made up
+    streetName: 'required|min:0|max:99999|string', // TODO: These are just made up
+    streetNumber: 'required|min:0|max:99999|numeric', // TODO: These are just made up
+    length: 'required|min:0|max:99999|numeric', // TODO: These are just made up
 };
 
 export default linkValidationModel;

--- a/src/validation/models/routePathValidationModel.ts
+++ b/src/validation/models/routePathValidationModel.ts
@@ -1,9 +1,18 @@
+const originRule = 'required|min:1|max:20|string';
+const destinationRule = 'required|min:1|max:20|string';
+const shortNameRule = 'required|min:1|max:20|string';
+const dateRule = 'required|date';
+
 const routePathValidationModel = {
-    origin: 'required|min:1|max:20|string',
-    destination: 'required|min:1|max:20|string',
-    length: 'required|numeric|min:0|max:99999',
-    shortName: 'required|min:1|max:20|string',
-    date: 'required|date',
+    originFi: originRule,
+    originSw: originRule,
+    destinationFi: destinationRule,
+    destinationSw: destinationRule,
+    routePathShortName: shortNameRule,
+    routePathShortNameSw: shortNameRule,
+    startTime: dateRule,
+    endTime: dateRule,
+    length: 'required|min:0|max:99999|numeric',
 };
 
 export default routePathValidationModel;

--- a/src/validation/models/stopValidationModel.ts
+++ b/src/validation/models/stopValidationModel.ts
@@ -1,7 +1,0 @@
-const stopValidatorModel = {
-    name: 'required|min:1|max:20|string', // TODO: These are just made up
-    radius: 'required|numeric|min:0|max:99999',
-
-};
-
-export default stopValidatorModel;

--- a/src/validation/models/stopValidationModel.ts
+++ b/src/validation/models/stopValidationModel.ts
@@ -1,10 +1,10 @@
 const nameRule = 'required|min:1|max:20|string'; // TODO: These are just made up
 
-const stopValidatorModel = {
+const stopValidationModel = {
     nameFi: nameRule,
     nameSe: nameRule,
     radius: 'required|min:0|max:99999|numeric',  // TODO: These are just made up
 
 };
 
-export default stopValidatorModel;
+export default stopValidationModel;

--- a/src/validation/models/stopValidatorModel.ts
+++ b/src/validation/models/stopValidatorModel.ts
@@ -1,0 +1,10 @@
+const nameRule = 'required|min:1|max:20|string'; // TODO: These are just made up
+
+const stopValidatorModel = {
+    nameFi: nameRule,
+    nameSe: nameRule,
+    radius: 'required|min:0|max:99999|numeric',  // TODO: These are just made up
+
+};
+
+export default stopValidatorModel;


### PR DESCRIPTION
Closes #756 

* merging this to #603 to help with double link creation bug
   * Making 2 links in a row doesn't work yet, will be fixed in #603

* input container is now more readable
* this also helps with some extra rendering issues, validate all input fields doens't trigger on change method calls as in previous version of inputContainer
* Node / stop validation is a bit different. Passing different validationModel depending on if validating node / stop. This won't work though if we add nodeValidationModel but it can be fixed later if nodeValidationModel is added