### PR TITLE
747 Visualize-link-duplicate

### DIFF
--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -257,9 +257,8 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                                 disabled={!this.props.isNewLink}
                             />
                             { transitType && this.transitTypeAlreadyExists(transitType) &&
-                                <div className={s.linkAlreadyFound}>
-                                    Linkki jolla on sama alkusolmu,
-                                    loppusolmu ja verkko on jo olemassa
+                                <div className={s.linkAlreadyFoundErrorText}>
+                                    Linkki on jo olemassa (sama alkusolmu, loppusolmu ja verkko).
                                 </div>
                             }
                         </div>

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -256,6 +256,12 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                                 toggleSelectedTransitType={this.selectTransitType}
                                 disabled={!this.props.isNewLink}
                             />
+                            { transitType && this.transitTypeAlreadyExists(transitType) &&
+                                <div className={s.linkAlreadyFound}>
+                                    Linkki jolla on sama alkusolmu,
+                                    loppusolmu ja verkko on jo olemassa
+                                </div>
+                            }
                         </div>
                     </div>
                     <div className={s.flexRow}>

--- a/src/components/sidebar/linkView/linkView.scss
+++ b/src/components/sidebar/linkView/linkView.scss
@@ -12,7 +12,7 @@
         overflow-y: auto;
         flex-grow: 1;
 
-        .linkAlreadyFound {
+        .linkAlreadyFoundErrorText {
             color: $errorRed;
             font-size: 12px;
             margin: 4px;

--- a/src/components/sidebar/linkView/linkView.scss
+++ b/src/components/sidebar/linkView/linkView.scss
@@ -12,6 +12,12 @@
         overflow-y: auto;
         flex-grow: 1;
 
+        .linkAlreadyFound {
+            color: $errorRed;
+            font-size: 12px;
+            margin: 4px;
+        }
+
         .column {
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
Closes #747 

Test by creating link with same start node and end node as old link. Toggle between transit type, transit types that are used should show error message.