### PR TITLE
721 validation bud when switching node type

### DIFF
--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -8,6 +8,14 @@ interface IViewFormBaseState {
     isEditingDisabled: boolean;
 }
 
+interface IValidateAllPropertiesOption {
+    clearModel: boolean;
+}
+
+const validateAllDefaultOptions: IValidateAllPropertiesOption = {
+    clearModel: true,
+};
+
 // TODO: refactor to use composition?
 // Inheritance is considered as a bad practice, react doesn't really support inheritance:
 // tslint:disable-next-line max-line-length
@@ -21,16 +29,7 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Pr
         EventManager.off('geometryChange', this.enableEditing);
     }
 
-    protected isFormValid = () => {
-        return !Object.values(this.state.invalidPropertiesMap)
-            .some(validatorResult => !validatorResult.isValid);
-    }
-
-    protected validateAllProperties = (validationModel: object, validationEntity: any) => {
-        this.setState({
-            invalidPropertiesMap: {},
-        });
-
+    private _validateUsingModel = (validationModel: object, validationEntity: any) => {
         Object.entries(validationModel).forEach(([property, validatorRule]) => {
             this.validateProperty(
                 validatorRule,
@@ -38,6 +37,28 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Pr
                 validationEntity[property],
             );
         });
+    }
+
+    protected isFormValid = () => {
+        return !Object.values(this.state.invalidPropertiesMap)
+            .some(validatorResult => !validatorResult.isValid);
+    }
+
+    protected validateAllProperties = (
+        validationModel: object, validationEntity: any, options?: IValidateAllPropertiesOption,
+    ) => {
+        const _options = { ...validateAllDefaultOptions, ...options };
+
+        if (_options.clearModel) {
+            this.setState(
+                {
+                    invalidPropertiesMap: {},
+                },
+                () => this._validateUsingModel(validationModel, validationEntity),
+            );
+        } else {
+            this._validateUsingModel(validationModel, validationEntity);
+        }
     }
 
     protected validateProperty = (validatorRule: string, property: string, value: any) => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -171,6 +171,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         const node = this.props.nodeStore!.node;
         if (nodeType === NodeType.STOP) {
             this.validateAllProperties(stopValidationModel, node.stop);
+            this.validateAllProperties(nodeValidationModel, node, { clearModel: false });
         } else {
             this.validateAllProperties(nodeValidationModel, node);
         }

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { observer } from 'mobx-react';
 import InputContainer from '~/components/sidebar/InputContainer';
 import { IStop } from '~/models';
 import municipalityCodeList from '~/codeLists/municipalityCodeList';
@@ -14,7 +13,7 @@ interface IStopFormProps {
     invalidPropertiesMap: object;
 }
 
-const StopForm = observer((
+const StopForm = (
     { stop, isEditingDisabled, onChange, invalidPropertiesMap }: IStopFormProps) => {
     return (
         <div className={s.stopView}>
@@ -227,6 +226,6 @@ const StopForm = observer((
             </div>
         </div>
     );
-});
+};
 
 export default StopForm;


### PR DESCRIPTION
Closes #721 

Fixes:
- bug that prevents you from saving crossroad/border if underlying stop is invalid.
- bug that does not validate node fields in stop view.
- bug that does not automatically show error messages when changing type from node to stop.