### PR TITLE
Fixed rendering start marker when creating new link

### DIFF
--- a/src/components/map/layers/NetworkLayers.tsx
+++ b/src/components/map/layers/NetworkLayers.tsx
@@ -9,7 +9,10 @@ import { LinkStore } from '~/stores/linkStore';
 import { MapStore } from '~/stores/mapStore';
 import { MapLayer, NetworkStore, NodeSize } from '~/stores/networkStore';
 import { RoutePathStore } from '~/stores/routePathStore';
-import EventManager from '~/util/EventManager';
+import EventManager, {
+    INetworkNodeClickParams,
+    INetworkLinkClickParams
+} from '~/util/EventManager';
 import TransitTypeHelper from '~/util/TransitTypeHelper';
 import TransitType from '~/enums/transitType';
 import NodeType from '~/enums/nodeType';
@@ -20,17 +23,6 @@ enum GeoserverLayer {
     Node = 'solmu',
     Link = 'linkki',
     Point = 'piste'
-}
-
-interface NetworkNodeClickParams {
-    nodeId: string;
-    nodeType: NodeType;
-}
-
-interface NetworkLinkClickParams {
-    startNodeId: string;
-    endNodeId: NodeType;
-    transitType: TransitType;
 }
 
 interface INetworkLayersProps {
@@ -270,7 +262,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
 
     private onNetworkNodeClick = (clickEvent: any) => {
         const properties = clickEvent.sourceTarget.properties;
-        const clickParams: NetworkNodeClickParams = {
+        const clickParams: INetworkNodeClickParams = {
             nodeId: properties.soltunnus,
             nodeType: properties.soltyyppi
         };
@@ -279,7 +271,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
 
     private onNetworkLinkClick = (clickEvent: any) => {
         const properties = clickEvent.sourceTarget.properties;
-        const clickParams: NetworkLinkClickParams = {
+        const clickParams: INetworkLinkClickParams = {
             startNodeId: properties.lnkalkusolmu,
             endNodeId: properties.lnkloppusolmu,
             transitType: properties.lnkverkko
@@ -363,5 +355,3 @@ class NetworkLayers extends Component<INetworkLayersProps> {
 }
 
 export default NetworkLayers;
-
-export { NetworkNodeClickParams, NetworkLinkClickParams };

--- a/src/components/map/layers/RoutePathLinkLayer.tsx
+++ b/src/components/map/layers/RoutePathLinkLayer.tsx
@@ -7,6 +7,7 @@ import { createCoherentLinesFromPolylines } from '~/util/geomHelper';
 import { PopupStore } from '~/stores/popupStore';
 import { MapStore, MapFilter } from '~/stores/mapStore';
 import StartNodeType from '~/enums/startNodeType';
+import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
 import NodeMarker from './markers/NodeMarker';
 import Marker from './markers/Marker';
 import ArrowDecorator from './ArrowDecorator';
@@ -61,6 +62,11 @@ class RoutePathLinkLayer extends Component<RoutePathLinkLayerProps> {
     }
     private renderNodes() {
         const routePathLinks = this.props.routePathLinks;
+        const onNodeClick = (node: INode) => () => {
+            const clickParams: IRoutePathNodeClickParams = { node };
+            EventManager.trigger('routePathNodeClick', clickParams);
+        };
+
         const nodes = routePathLinks.map((routePathLink, index) => {
             const node = routePathLink.startNode;
             return (
@@ -75,6 +81,7 @@ class RoutePathLinkLayer extends Component<RoutePathLinkLayerProps> {
                         routePathLink.startNodeTimeAlignmentStop !== '0'
                     }
                     onContextMenu={this.openPopup(routePathLink.startNode)}
+                    onClick={onNodeClick(node)}
                 />
             );
         });
@@ -88,6 +95,7 @@ class RoutePathLinkLayer extends Component<RoutePathLinkLayerProps> {
                 isDisabled={false} // Last node can't be disabled
                 isTimeAlignmentStop={false} // Last node can't be a time alignment stop
                 onContextMenu={this.openPopup(lastRoutePathLink.endNode)}
+                onClick={onNodeClick(node)}
             />
         );
         return nodes;

--- a/src/components/map/layers/RoutePathLinkLayer.tsx
+++ b/src/components/map/layers/RoutePathLinkLayer.tsx
@@ -7,7 +7,7 @@ import { createCoherentLinesFromPolylines } from '~/util/geomHelper';
 import { PopupStore } from '~/stores/popupStore';
 import { MapStore, MapFilter } from '~/stores/mapStore';
 import StartNodeType from '~/enums/startNodeType';
-import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
+import EventManager, { INodeClickParams } from '~/util/EventManager';
 import NodeMarker from './markers/NodeMarker';
 import Marker from './markers/Marker';
 import ArrowDecorator from './ArrowDecorator';
@@ -63,8 +63,8 @@ class RoutePathLinkLayer extends Component<RoutePathLinkLayerProps> {
     private renderNodes() {
         const routePathLinks = this.props.routePathLinks;
         const onNodeClick = (node: INode) => () => {
-            const clickParams: IRoutePathNodeClickParams = { node };
-            EventManager.trigger('routePathNodeClick', clickParams);
+            const clickParams: INodeClickParams = { node };
+            EventManager.trigger('nodeClick', clickParams);
         };
 
         const nodes = routePathLinks.map((routePathLink, index) => {

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -148,7 +148,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         );
     };
 
-    private renderMarker = () => {
+    private renderStartMarker = () => {
         const startMarkerCoordinates = this.props.linkStore!
             .startMarkerCoordinates;
         if (!startMarkerCoordinates) return null;
@@ -164,7 +164,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
     render() {
         const link = this.props.linkStore!.link;
         if (!link || !link.geometry) {
-            return null;
+            return <>{this.renderStartMarker()}</>;
         }
 
         this.drawEditableLink();
@@ -173,7 +173,7 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
             <>
                 {this.renderLinkDecorator()}
                 {this.renderNodes()}
-                {this.renderMarker()}
+                {this.renderStartMarker()}
             </>
         );
     }

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { withLeaflet } from 'react-leaflet';
 import { inject, observer } from 'mobx-react';
 import { IReactionDisposer, reaction } from 'mobx';
-import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
+import EventManager, { INodeClickParams } from '~/util/EventManager';
 import { LoginStore } from '~/stores/loginStore';
 import { INode, ILink } from '~/models';
 import { LinkStore } from '~/stores/linkStore';
@@ -137,8 +137,8 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
     private renderNode = (node: INode) => {
         if (!node) return null;
         const onNodeClick = () => {
-            const clickParams: IRoutePathNodeClickParams = { node };
-            EventManager.trigger('routePathNodeClick', clickParams);
+            const clickParams: INodeClickParams = { node };
+            EventManager.trigger('nodeClick', clickParams);
         };
 
         return (

--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { withLeaflet } from 'react-leaflet';
 import { inject, observer } from 'mobx-react';
 import { IReactionDisposer, reaction } from 'mobx';
-import EventManager from '~/util/EventManager';
+import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
 import { LoginStore } from '~/stores/loginStore';
 import { INode, ILink } from '~/models';
 import { LinkStore } from '~/stores/linkStore';
@@ -136,13 +136,17 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
 
     private renderNode = (node: INode) => {
         if (!node) return null;
+        const onNodeClick = () => {
+            const clickParams: IRoutePathNodeClickParams = { node };
+            EventManager.trigger('routePathNodeClick', clickParams);
+        };
 
         return (
             <NodeMarker
                 key={node.id}
                 isSelected={this.props.mapStore!.selectedNodeId === node.id}
                 isDraggable={false}
-                onClickEventParams={{ nodeId: node.id }}
+                onClick={onNodeClick}
                 node={node}
             />
         );

--- a/src/components/map/layers/edit/EditRoutePathLayer.tsx
+++ b/src/components/map/layers/edit/EditRoutePathLayer.tsx
@@ -11,7 +11,7 @@ import { MapStore, MapFilter } from '~/stores/mapStore';
 import { ToolbarStore } from '~/stores/toolbarStore';
 import ToolbarTool from '~/enums/toolbarTool';
 import RoutePathNeighborLinkService from '~/services/routePathNeighborLinkService';
-import EventManager, { INodeClickParams } from '~/util/EventManager';
+import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
 import NodeMarker from '../markers/NodeMarker';
 import Marker from '../markers/Marker';
 import ArrowDecorator from '../ArrowDecorator';
@@ -118,15 +118,15 @@ class EditRoutePathLayer extends Component<
             if (isNodeHighlighted) {
                 onNodeClick = () => {
                     this.fetchNeighborRoutePathLinks(node, linkOrderNumber);
-                    const clickParams: INodeClickParams = { node };
-                    EventManager.trigger('nodeClick', clickParams);
+                    const clickParams: IRoutePathNodeClickParams = { node };
+                    EventManager.trigger('routePathNodeClick', clickParams);
                 };
             }
         } else {
             onNodeClick = () => {
                 this.highlightItemById(node.id);
-                const clickParams: INodeClickParams = { node };
-                EventManager.trigger('nodeClick', clickParams);
+                const clickParams: IRoutePathNodeClickParams = { node };
+                EventManager.trigger('routePathNodeClick', clickParams);
             };
             isNodeHighlighted = this.props.routePathStore!.isMapItemHighlighted(
                 node.id

--- a/src/components/map/layers/edit/EditRoutePathLayer.tsx
+++ b/src/components/map/layers/edit/EditRoutePathLayer.tsx
@@ -11,7 +11,7 @@ import { MapStore, MapFilter } from '~/stores/mapStore';
 import { ToolbarStore } from '~/stores/toolbarStore';
 import ToolbarTool from '~/enums/toolbarTool';
 import RoutePathNeighborLinkService from '~/services/routePathNeighborLinkService';
-import EventManager, { IRoutePathNodeClickParams } from '~/util/EventManager';
+import EventManager, { INodeClickParams } from '~/util/EventManager';
 import NodeMarker from '../markers/NodeMarker';
 import Marker from '../markers/Marker';
 import ArrowDecorator from '../ArrowDecorator';
@@ -118,15 +118,15 @@ class EditRoutePathLayer extends Component<
             if (isNodeHighlighted) {
                 onNodeClick = () => {
                     this.fetchNeighborRoutePathLinks(node, linkOrderNumber);
-                    const clickParams: IRoutePathNodeClickParams = { node };
-                    EventManager.trigger('routePathNodeClick', clickParams);
+                    const clickParams: INodeClickParams = { node };
+                    EventManager.trigger('nodeClick', clickParams);
                 };
             }
         } else {
             onNodeClick = () => {
                 this.highlightItemById(node.id);
-                const clickParams: IRoutePathNodeClickParams = { node };
-                EventManager.trigger('routePathNodeClick', clickParams);
+                const clickParams: INodeClickParams = { node };
+                EventManager.trigger('nodeClick', clickParams);
             };
             isNodeHighlighted = this.props.routePathStore!.isMapItemHighlighted(
                 node.id

--- a/src/components/map/layers/markers/NodeMarker.tsx
+++ b/src/components/map/layers/markers/NodeMarker.tsx
@@ -8,7 +8,6 @@ import { INode } from '~/models/index';
 import NodeLocationType from '~/types/NodeLocationType';
 import NodeType from '~/enums/nodeType';
 import { MapStore, NodeLabel } from '~/stores/mapStore';
-import EventManager from '~/util/EventManager';
 import NodeHelper from '~/util/nodeHelper';
 import LeafletUtils from '~/util/leafletUtils';
 import MarkerPopup from './MarkerPopup';
@@ -22,7 +21,6 @@ interface INodeMarkerProps {
     onClick?: Function;
     isDraggable?: boolean;
     isHighlighted?: boolean;
-    onClickEventParams?: any;
     forcedVisibleNodeLabels?: NodeLabel[];
     markerClasses?: string[];
     // static markup language (HTML)
@@ -197,12 +195,6 @@ class NodeMarker extends Component<INodeMarkerProps> {
     private onMarkerClick = () => {
         if (this.props.onClick) {
             this.props.onClick();
-        }
-        if (this.props.onClickEventParams) {
-            EventManager.trigger(
-                'routePathNodeClick',
-                this.props.onClickEventParams
-            );
         }
     };
 

--- a/src/components/map/layers/markers/NodeMarker.tsx
+++ b/src/components/map/layers/markers/NodeMarker.tsx
@@ -199,7 +199,10 @@ class NodeMarker extends Component<INodeMarkerProps> {
             this.props.onClick();
         }
         if (this.props.onClickEventParams) {
-            EventManager.trigger('nodeClick', this.props.onClickEventParams);
+            EventManager.trigger(
+                'routePathNodeClick',
+                this.props.onClickEventParams
+            );
         }
     };
 

--- a/src/components/map/tools/AddNetworkLinkTool.ts
+++ b/src/components/map/tools/AddNetworkLinkTool.ts
@@ -2,7 +2,7 @@ import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
 import EventManager, {
-    IRoutePathNodeClickParams,
+    INodeClickParams,
     INetworkNodeClickParams
 } from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
@@ -24,16 +24,16 @@ class AddNetworkLinkTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.node);
         NetworkStore.showMapLayer(MapLayer.nodeWithoutLink);
         NetworkStore.showMapLayer(MapLayer.link);
-        EventManager.on('routePathNodeClick', this.onRoutePathNodeClick);
+        EventManager.on('nodeClick', this.onnodeClick);
         EventManager.on('networkNodeClick', this.onNetworkNodeClick);
     }
     public deactivate() {
         this.resetTool();
-        EventManager.off('routePathNodeClick', this.onRoutePathNodeClick);
+        EventManager.off('nodeClick', this.onnodeClick);
         EventManager.off('networkNodeClick', this.onNetworkNodeClick);
     }
-    private onRoutePathNodeClick = async (clickEvent: CustomEvent) => {
-        const nodeClickParams: IRoutePathNodeClickParams = clickEvent.detail;
+    private onnodeClick = async (clickEvent: CustomEvent) => {
+        const nodeClickParams: INodeClickParams = clickEvent.detail;
         this.setStartOrEndNode(nodeClickParams.node.id);
     };
 

--- a/src/components/map/tools/AddNetworkLinkTool.ts
+++ b/src/components/map/tools/AddNetworkLinkTool.ts
@@ -1,7 +1,10 @@
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
-import EventManager from '~/util/EventManager';
+import EventManager, {
+    INodeClickParams,
+    INetworkNodeClickParams
+} from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
 import NodeService from '~/services/nodeService';
 import ErrorStore from '~/stores/errorStore';
@@ -12,6 +15,7 @@ import BaseTool from './BaseTool';
 
 class AddNetworkLinkTool implements BaseTool {
     private startNodeId: string | null = null;
+    private endNodeId: string | null = null;
     public toolType = ToolbarTool.AddNetworkLink;
     public toolHelpHeader = 'Luo uusi linkki';
     public toolHelpText =
@@ -21,15 +25,25 @@ class AddNetworkLinkTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.nodeWithoutLink);
         NetworkStore.showMapLayer(MapLayer.link);
         EventManager.on('nodeClick', this.onNodeClick);
-        EventManager.on('networkNodeClick', this.onNodeClick);
+        EventManager.on('networkNodeClick', this.onNetworkNodeClick);
     }
     public deactivate() {
         this.resetTool();
         EventManager.off('nodeClick', this.onNodeClick);
-        EventManager.off('networkNodeClick', this.onNodeClick);
+        EventManager.off('networkNodeClick', this.onNetworkNodeClick);
     }
     private onNodeClick = async (clickEvent: CustomEvent) => {
-        const nodeId = clickEvent.detail.nodeId;
+        const nodeClickParams: INodeClickParams = clickEvent.detail;
+        this.setStartOrEndNode(nodeClickParams.node.id);
+    };
+
+    private onNetworkNodeClick = async (clickEvent: CustomEvent) => {
+        const networkNodeClickParams: INetworkNodeClickParams =
+            clickEvent.detail;
+        this.setStartOrEndNode(networkNodeClickParams.nodeId);
+    };
+
+    private setStartOrEndNode = async (nodeId: string) => {
         if (!this.startNodeId) {
             this.startNodeId = nodeId;
             try {
@@ -39,20 +53,22 @@ class AddNetworkLinkTool implements BaseTool {
                 ErrorStore.addError(`Alkusolmun ${nodeId} haku epäonnistui`);
             }
         } else {
-            const startNodeId = this.startNodeId;
-            const endNodeId = nodeId;
-            if (startNodeId === endNodeId) return;
+            this.endNodeId = nodeId;
+            if (this.startNodeId === this.endNodeId) return;
             // TODO?
             // if (!this.isNewLinkValid(clickEvent, startNodeId, endNodeId)) return;
-
-            const newLinkViewLink = routeBuilder
-                .to(SubSites.newLink)
-                .toTarget([startNodeId, endNodeId].join(','))
-                .toLink();
-            navigator.goTo(newLinkViewLink);
-
-            ToolbarStore.selectTool(null);
+            this.redirectToNewLinkView();
         }
+    };
+
+    private redirectToNewLinkView = () => {
+        const newLinkViewLink = routeBuilder
+            .to(SubSites.newLink)
+            .toTarget([this.startNodeId, this.endNodeId].join(','))
+            .toLink();
+        navigator.goTo(newLinkViewLink);
+
+        ToolbarStore.selectTool(null);
     };
 
     // TODO?
@@ -74,6 +90,7 @@ class AddNetworkLinkTool implements BaseTool {
 
     private resetTool = () => {
         this.startNodeId = null;
+        this.endNodeId = null;
         LinkStore.setMarkerCoordinates(null);
     };
 }

--- a/src/components/map/tools/AddNetworkLinkTool.ts
+++ b/src/components/map/tools/AddNetworkLinkTool.ts
@@ -2,7 +2,7 @@ import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
 import EventManager, {
-    INodeClickParams,
+    IRoutePathNodeClickParams,
     INetworkNodeClickParams
 } from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
@@ -24,16 +24,16 @@ class AddNetworkLinkTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.node);
         NetworkStore.showMapLayer(MapLayer.nodeWithoutLink);
         NetworkStore.showMapLayer(MapLayer.link);
-        EventManager.on('nodeClick', this.onNodeClick);
+        EventManager.on('routePathNodeClick', this.onRoutePathNodeClick);
         EventManager.on('networkNodeClick', this.onNetworkNodeClick);
     }
     public deactivate() {
         this.resetTool();
-        EventManager.off('nodeClick', this.onNodeClick);
+        EventManager.off('routePathNodeClick', this.onRoutePathNodeClick);
         EventManager.off('networkNodeClick', this.onNetworkNodeClick);
     }
-    private onNodeClick = async (clickEvent: CustomEvent) => {
-        const nodeClickParams: INodeClickParams = clickEvent.detail;
+    private onRoutePathNodeClick = async (clickEvent: CustomEvent) => {
+        const nodeClickParams: IRoutePathNodeClickParams = clickEvent.detail;
         this.setStartOrEndNode(nodeClickParams.node.id);
     };
 

--- a/src/components/map/tools/CopyRoutePathSegmentTool.ts
+++ b/src/components/map/tools/CopyRoutePathSegmentTool.ts
@@ -1,5 +1,5 @@
 import EventManager, {
-    INodeClickParams,
+    IRoutePathNodeClickParams,
     INetworkNodeClickParams
 } from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
@@ -21,17 +21,17 @@ class CopyRoutePathSegmentTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.node);
         NetworkStore.showMapLayer(MapLayer.link);
         EventManager.on('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.on('nodeClick', this.onNodeClick);
+        EventManager.on('routePathNodeClick', this.onRoutePathNodeClick);
     }
     public deactivate() {
         EventManager.off('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.off('nodeClick', this.onNodeClick);
+        EventManager.off('routePathNodeClick', this.onRoutePathNodeClick);
         RoutePathCopySegmentStore.clear();
     }
 
-    private onNodeClick = (clickEvent: CustomEvent) => {
+    private onRoutePathNodeClick = (clickEvent: CustomEvent) => {
         const setNodeType = RoutePathCopySegmentStore.setNodeType;
-        const params: INodeClickParams = clickEvent.detail;
+        const params: IRoutePathNodeClickParams = clickEvent.detail;
 
         if (setNodeType === 'startNode') this.selectStartNode(params.node.id);
         else this.selectEndNode(params.node.id);

--- a/src/components/map/tools/CopyRoutePathSegmentTool.ts
+++ b/src/components/map/tools/CopyRoutePathSegmentTool.ts
@@ -1,4 +1,7 @@
-import EventManager from '~/util/EventManager';
+import EventManager, {
+    INodeClickParams,
+    INetworkNodeClickParams
+} from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
 import ErrorStore from '~/stores/errorStore';
 import NetworkStore, { MapLayer } from '~/stores/networkStore';
@@ -7,8 +10,6 @@ import RoutePathStore from '~/stores/routePathStore';
 import NodeService from '~/services/nodeService';
 import RoutePathSegmentService from '~/services/routePathSegmentService';
 import BaseTool from './BaseTool';
-import { IEditRoutePathLayerNodeClickParams } from '../layers/edit/EditRoutePathLayer';
-import { NetworkNodeClickParams } from '../layers/NetworkLayers';
 
 class CopyRoutePathSegmentTool implements BaseTool {
     public toolType = ToolbarTool.CopyRoutePathSegmentTool;
@@ -30,7 +31,7 @@ class CopyRoutePathSegmentTool implements BaseTool {
 
     private onNodeClick = (clickEvent: CustomEvent) => {
         const setNodeType = RoutePathCopySegmentStore.setNodeType;
-        const params: IEditRoutePathLayerNodeClickParams = clickEvent.detail;
+        const params: INodeClickParams = clickEvent.detail;
 
         if (setNodeType === 'startNode') this.selectStartNode(params.node.id);
         else this.selectEndNode(params.node.id);
@@ -38,7 +39,7 @@ class CopyRoutePathSegmentTool implements BaseTool {
 
     private onNetworkNodeClick = (clickEvent: CustomEvent) => {
         const setNodeType = RoutePathCopySegmentStore.setNodeType;
-        const params: NetworkNodeClickParams = clickEvent.detail;
+        const params: INetworkNodeClickParams = clickEvent.detail;
 
         if (setNodeType === 'startNode') this.selectStartNode(params.nodeId);
         else this.selectEndNode(params.nodeId);

--- a/src/components/map/tools/CopyRoutePathSegmentTool.ts
+++ b/src/components/map/tools/CopyRoutePathSegmentTool.ts
@@ -1,5 +1,5 @@
 import EventManager, {
-    IRoutePathNodeClickParams,
+    INodeClickParams,
     INetworkNodeClickParams
 } from '~/util/EventManager';
 import ToolbarTool from '~/enums/toolbarTool';
@@ -21,17 +21,17 @@ class CopyRoutePathSegmentTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.node);
         NetworkStore.showMapLayer(MapLayer.link);
         EventManager.on('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.on('routePathNodeClick', this.onRoutePathNodeClick);
+        EventManager.on('nodeClick', this.onnodeClick);
     }
     public deactivate() {
         EventManager.off('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.off('routePathNodeClick', this.onRoutePathNodeClick);
+        EventManager.off('nodeClick', this.onnodeClick);
         RoutePathCopySegmentStore.clear();
     }
 
-    private onRoutePathNodeClick = (clickEvent: CustomEvent) => {
+    private onnodeClick = (clickEvent: CustomEvent) => {
         const setNodeType = RoutePathCopySegmentStore.setNodeType;
-        const params: IRoutePathNodeClickParams = clickEvent.detail;
+        const params: INodeClickParams = clickEvent.detail;
 
         if (setNodeType === 'startNode') this.selectStartNode(params.node.id);
         else this.selectEndNode(params.node.id);

--- a/src/components/map/tools/ExtendRoutePathTool.ts
+++ b/src/components/map/tools/ExtendRoutePathTool.ts
@@ -2,11 +2,9 @@ import RoutePathStore from '~/stores/routePathStore';
 import NetworkStore, { MapLayer } from '~/stores/networkStore';
 import NodeType from '~/enums/nodeType';
 import ToolbarTool from '~/enums/toolbarTool';
-import EventManager from '~/util/EventManager';
+import EventManager, { INetworkNodeClickParams } from '~/util/EventManager';
 import RoutePathNeighborLinkService from '~/services/routePathNeighborLinkService';
 import BaseTool from './BaseTool';
-import { IEditRoutePathLayerNodeClickParams } from '../layers/edit/EditRoutePathLayer';
-import { NetworkNodeClickParams } from '../layers/NetworkLayers';
 
 /**
  * Tool for creating new routePath
@@ -20,12 +18,10 @@ class ExtendRoutePathTool implements BaseTool {
         NetworkStore.showMapLayer(MapLayer.node);
         NetworkStore.showMapLayer(MapLayer.link);
         EventManager.on('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.on('nodeClick', this.onNodeClick);
     }
     public deactivate() {
         this.reset();
         EventManager.off('networkNodeClick', this.onNetworkNodeClick);
-        EventManager.off('nodeClick', this.onNodeClick);
     }
 
     private reset() {
@@ -34,7 +30,7 @@ class ExtendRoutePathTool implements BaseTool {
 
     private onNetworkNodeClick = async (clickEvent: CustomEvent) => {
         if (!this.isNetworkNodesInteractive()) return;
-        const params: NetworkNodeClickParams = clickEvent.detail;
+        const params: INetworkNodeClickParams = clickEvent.detail;
         if (params.nodeType !== NodeType.STOP) return;
         const queryResult = await RoutePathNeighborLinkService.fetchNeighborRoutePathLinks(
             params.nodeId,
@@ -48,23 +44,6 @@ class ExtendRoutePathTool implements BaseTool {
             RoutePathStore!.setNeighborToAddType(
                 queryResult!.neighborToAddType
             );
-        }
-    };
-
-    private onNodeClick = async (clickEvent: CustomEvent) => {
-        const params: IEditRoutePathLayerNodeClickParams = clickEvent.detail;
-        const node = params.node;
-        const linkOrderNumber = params.linkOrderNumber;
-        const queryResult = await RoutePathNeighborLinkService.fetchNeighborRoutePathLinks(
-            node.id,
-            RoutePathStore!.routePath!,
-            linkOrderNumber
-        );
-        if (queryResult) {
-            RoutePathStore!.setNeighborRoutePathLinks(
-                queryResult.neighborLinks
-            );
-            RoutePathStore!.setNeighborToAddType(queryResult.neighborToAddType);
         }
     };
 

--- a/src/components/map/tools/SelectNetworkEntityTool.ts
+++ b/src/components/map/tools/SelectNetworkEntityTool.ts
@@ -1,13 +1,12 @@
 import ToolbarTool from '~/enums/toolbarTool';
-import EventManager from '~/util/EventManager';
+import EventManager, {
+    INetworkNodeClickParams,
+    INetworkLinkClickParams
+} from '~/util/EventManager';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import navigator from '~/routing/navigator';
 import BaseTool from './BaseTool';
-import {
-    NetworkNodeClickParams,
-    NetworkLinkClickParams
-} from '../layers/NetworkLayers';
 
 /**
  * Tool for creating new routePath
@@ -24,7 +23,7 @@ class SelectNetworkEntityTool implements BaseTool {
     }
 
     private onNetworkNodeClick = async (clickEvent: CustomEvent) => {
-        const params: NetworkNodeClickParams = clickEvent.detail;
+        const params: INetworkNodeClickParams = clickEvent.detail;
 
         const nodeViewLink = routeBuilder
             .to(SubSites.node)
@@ -33,7 +32,7 @@ class SelectNetworkEntityTool implements BaseTool {
         navigator.goTo(nodeViewLink);
     };
     private onNetworkLinkClick = async (clickEvent: CustomEvent) => {
-        const params: NetworkLinkClickParams = clickEvent.detail;
+        const params: INetworkLinkClickParams = clickEvent.detail;
 
         const linkViewLink = routeBuilder
             .to(SubSites.link)

--- a/src/util/EventManager.ts
+++ b/src/util/EventManager.ts
@@ -9,7 +9,7 @@ type eventName =
     | 'undo'
     | 'redo'
     | 'mapClick'
-    | 'routePathNodeClick'
+    | 'nodeClick'
     | 'networkNodeClick'
     | 'networkLinkClick'
     | 'geometryChange';
@@ -31,7 +31,7 @@ class EventManager {
     }
 }
 
-interface IRoutePathNodeClickParams {
+interface INodeClickParams {
     node: INode;
 }
 
@@ -48,8 +48,4 @@ interface INetworkLinkClickParams {
 
 export default new EventManager();
 
-export {
-    IRoutePathNodeClickParams,
-    INetworkNodeClickParams,
-    INetworkLinkClickParams
-};
+export { INodeClickParams, INetworkNodeClickParams, INetworkLinkClickParams };

--- a/src/util/EventManager.ts
+++ b/src/util/EventManager.ts
@@ -9,7 +9,7 @@ type eventName =
     | 'undo'
     | 'redo'
     | 'mapClick'
-    | 'nodeClick' // TODO: rename as onRoutePathNodeClick?
+    | 'routePathNodeClick'
     | 'networkNodeClick'
     | 'networkLinkClick'
     | 'geometryChange';
@@ -31,7 +31,7 @@ class EventManager {
     }
 }
 
-interface INodeClickParams {
+interface IRoutePathNodeClickParams {
     node: INode;
 }
 
@@ -48,4 +48,8 @@ interface INetworkLinkClickParams {
 
 export default new EventManager();
 
-export { INodeClickParams, INetworkNodeClickParams, INetworkLinkClickParams };
+export {
+    IRoutePathNodeClickParams,
+    INetworkNodeClickParams,
+    INetworkLinkClickParams
+};

--- a/src/util/EventManager.ts
+++ b/src/util/EventManager.ts
@@ -1,3 +1,7 @@
+import { INode } from '~/models';
+import NodeType from '~/enums/nodeType';
+import TransitType from '~/enums/transitType';
+
 type eventName =
     | 'enter'
     | 'arrowUp'
@@ -27,4 +31,21 @@ class EventManager {
     }
 }
 
+interface INodeClickParams {
+    node: INode;
+}
+
+interface INetworkNodeClickParams {
+    nodeId: string;
+    nodeType: NodeType;
+}
+
+interface INetworkLinkClickParams {
+    startNodeId: string;
+    endNodeId: NodeType;
+    transitType: TransitType;
+}
+
 export default new EventManager();
+
+export { INodeClickParams, INetworkNodeClickParams, INetworkLinkClickParams };


### PR DESCRIPTION
Closes #942 

Fixes:
* if node is open, green marker is not being drawn on map
* new link tool: link node click doesn't work at link/ page
* new link tool: routePathNode click doesn't work at routes/ page
* new link tool: routePathNode click doens't work at routePath/ page