### PR TITLE
985 focus to route paths

### DIFF
--- a/src/components/map/layers/RouteLayer.tsx
+++ b/src/components/map/layers/RouteLayer.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import L from 'leaflet';
 import { withLeaflet } from 'react-leaflet';
 import { observer, inject } from 'mobx-react';
 import { MapStore } from '~/stores/mapStore';
@@ -29,22 +28,6 @@ class RouteLayer extends Component<RouteLayerProps, IRouteLayerState> {
         };
     }
 
-    private calculateBounds() {
-        const bounds: L.LatLngBounds = new L.LatLngBounds([]);
-
-        this.props.routes.forEach(route => {
-            route.routePaths.forEach(routePath => {
-                routePath.routePathLinks.forEach(routePathLink => {
-                    routePathLink.geometry.forEach(pos => bounds.extend(pos));
-                });
-            });
-        });
-
-        if (bounds.isValid()) {
-            this.props.mapStore!.setMapBounds(bounds);
-        }
-    }
-
     componentDidUpdate(prevProps: RouteLayerProps) {
         // TODO: Fix this check when calculateBounds() is called
         const prevRoutePathIds = prevProps.routes
@@ -59,7 +42,6 @@ class RouteLayer extends Component<RouteLayerProps, IRouteLayerState> {
             .join(':');
         const routePathsChanged = prevRoutePathIds !== currentRoutePathIds;
         if (routePathsChanged) {
-            this.calculateBounds();
             this.setState({
                 selectedPolylines: []
             });

--- a/src/components/map/layers/RouteLayer.tsx
+++ b/src/components/map/layers/RouteLayer.tsx
@@ -28,26 +28,6 @@ class RouteLayer extends Component<RouteLayerProps, IRouteLayerState> {
         };
     }
 
-    componentDidUpdate(prevProps: RouteLayerProps) {
-        // TODO: Fix this check when calculateBounds() is called
-        const prevRoutePathIds = prevProps.routes
-            .map(route =>
-                route.routePaths.map(rPath => rPath.internalId).join(':')
-            )
-            .join(':');
-        const currentRoutePathIds = this.props.routes
-            .map(route =>
-                route.routePaths.map(rPath => rPath.internalId).join(':')
-            )
-            .join(':');
-        const routePathsChanged = prevRoutePathIds !== currentRoutePathIds;
-        if (routePathsChanged) {
-            this.setState({
-                selectedPolylines: []
-            });
-        }
-    }
-
     private toggleHighlight = (internalId: string) => (target: any) => () => {
         let selectedPolylines = this.state.selectedPolylines;
 

--- a/src/components/sidebar/routeListView/RouteItem.tsx
+++ b/src/components/sidebar/routeListView/RouteItem.tsx
@@ -30,14 +30,17 @@ interface IRouteItemProps {
 class RouteItem extends React.Component<IRouteItemProps> {
     async componentDidMount() {
         let index = 0;
+        const promises: Promise<void>[] = [];
         for (const routePath of this.props.route.routePaths) {
             if (index < 2) {
-                await this.props.routeListStore!.toggleRoutePathVisibility(
+                const promise = this.props.routeListStore!.toggleRoutePathVisibility(
                     routePath.internalId
                 );
+                promises.push(promise);
             }
             index += 1;
         }
+        await Promise.all(promises);
         this.calculateBounds();
     }
 

--- a/src/components/sidebar/routeListView/RouteItem.tsx
+++ b/src/components/sidebar/routeListView/RouteItem.tsx
@@ -1,9 +1,11 @@
 import { inject, observer } from 'mobx-react';
 import React from 'react';
+import L from 'leaflet';
 import classNames from 'classnames';
 import { FiInfo } from 'react-icons/fi';
 import Moment from 'moment';
 import { RouteListStore } from '~/stores/routeListStore';
+import { MapStore } from '~/stores/mapStore';
 import LineHelper from '~/util/lineHelper';
 import { dateToDateString } from '~/util/dateFormatHelper';
 import TransitTypeHelper from '~/util/TransitTypeHelper';
@@ -19,21 +21,43 @@ import * as s from './routeItem.scss';
 
 interface IRouteItemProps {
     routeListStore?: RouteListStore;
+    mapStore?: MapStore;
     route: IRoute;
 }
 
-@inject('routeListStore')
+@inject('routeListStore', 'mapStore')
 @observer
 class RouteItem extends React.Component<IRouteItemProps> {
     async componentDidMount() {
-        this.props.route.routePaths.forEach((routePath, index) => {
-            // Make two first route paths visible by default
+        let index = 0;
+        for (const routePath of this.props.route.routePaths) {
             if (index < 2) {
-                this.props.routeListStore!.toggleRoutePathVisibility(
+                await this.props.routeListStore!.toggleRoutePathVisibility(
                     routePath.internalId
                 );
             }
+            index += 1;
+        }
+        this.calculateBounds();
+    }
+
+    private calculateBounds() {
+        const routes = this.props.routeListStore!.routes;
+        const bounds: L.LatLngBounds = new L.LatLngBounds([]);
+
+        routes.forEach(route => {
+            route.routePaths.forEach(routePath => {
+                routePath.routePathLinks.forEach(routePathLink => {
+                    routePathLink.geometry.forEach(pos => {
+                        bounds.extend(pos);
+                    });
+                });
+            });
         });
+
+        if (bounds.isValid()) {
+            this.props.mapStore!.setMapBounds(bounds);
+        }
     }
 
     private closeRoute = () => {
@@ -104,12 +128,14 @@ class RouteItem extends React.Component<IRouteItemProps> {
                 this.props.routeListStore!.toggleRoutePathVisibility(
                     routePath.internalId
                 );
+                this.calculateBounds();
             };
 
             const openRoutePathView = () => {
                 const routePathViewLink = routeBuilder
                     .to(subSites.routePath)
-                    .toTarget(':id',
+                    .toTarget(
+                        ':id',
                         [
                             routePath.routeId,
                             Moment(routePath.startTime).format(


### PR DESCRIPTION
Closes #985
* Now map gets centered to opened routePaths when user opens map
* Removed also unnecessary selectedPolylines[] reset when route was removed / added to the list at /routes/ page