### PR TITLE
916 automatically fill stop postal number and address

### DIFF
--- a/src/components/map/AddressSearch.tsx
+++ b/src/components/map/AddressSearch.tsx
@@ -135,12 +135,12 @@ class AddressSearch extends Component<
         }
     };
     private requestAddress = async (value: string) => {
-        const GEOCODER_ADDRESS = constants.GEOCODER_ADDRESS;
+        const ADDRESS_GEOCODING_URL = constants.ADDRESS_GEOCODING_URL;
         const SEARCH_RESULT_COUNT = constants.ADDRESS_SEARCH_RESULT_COUNT;
         const center = this.map.getCenter();
         const lat = center.lat;
         const lng = center.lng;
-        const requestUrl = `${GEOCODER_ADDRESS}?text=${value}&size=${SEARCH_RESULT_COUNT}&focus.point.lat=${lat}&focus.point.lon=${lng}`;
+        const requestUrl = `${ADDRESS_GEOCODING_URL}?text=${value}&size=${SEARCH_RESULT_COUNT}&focus.point.lat=${lat}&focus.point.lon=${lng}`;
 
         const response = await ApiClient.sendRequest(
             RequestMethod.GET,

--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -8,7 +8,7 @@ interface IViewFormBaseState {
     isEditingDisabled: boolean; // TODO: remove
 }
 
-// TODO: refactor to use composition?
+// TODO: refactor to use composition / refactor to its own store?
 // Inheritance is considered as a bad practice, react doesn't really support inheritance:
 // https://stackoverflow.com/questions/31072841/componentdidmount-method-not-triggered-when-using-inherited-es6-react-class
 class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<

--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -5,7 +5,7 @@ import EventManager from '~/util/EventManager';
 interface IViewFormBaseState {
     isLoading: boolean;
     invalidPropertiesMap: object;
-    isEditingDisabled: boolean;
+    isEditingDisabled: boolean; // TODO: remove
 }
 
 // TODO: refactor to use composition?
@@ -15,10 +15,12 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<
     Props,
     State
 > {
+    // TODO: remove
     componentDidMount() {
         EventManager.on('geometryChange', this.enableEditing);
     }
 
+    // TODO: remove
     componentWillUnmount() {
         EventManager.off('geometryChange', this.enableEditing);
     }
@@ -74,6 +76,7 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<
         });
     };
 
+    // TODO: remove
     protected toggleIsEditingDisabled = () => {
         const isEditingDisabled = !this.state.isEditingDisabled;
         if (isEditingDisabled) {
@@ -88,6 +91,13 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<
         }
     };
 
+    protected clearInvalidPropertiesMap = () => {
+        this.setState({
+            invalidPropertiesMap: {}
+        });
+    };
+
+    // TODO: remove
     protected enableEditing = () => {
         this.setState({ isEditingDisabled: false });
     };

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -13,7 +13,8 @@ const commonConstants = {
     SMALL_INT_MAX_VALUE: 32767, // Max value at PostgreSQL (2 bytes)
     MAP_LAYERS_MIN_ZOOM_LEVEL: 15,
     NEW_OBJECT_TAG: 'new-',
-    GEOCODER_ADDRESS: 'https://api.digitransit.fi/geocoding/v1/search',
+    ADDRESS_GEOCODING_URL: 'https://api.digitransit.fi/geocoding/v1/search',
+    REVERSE_GEOCODING_URL: 'https://api.digitransit.fi/geocoding/v1/reverse',
     ADDRESS_SEARCH_RESULT_COUNT: 10
 };
 
@@ -35,4 +36,4 @@ const productionConstants = {
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-export default (isDevelopment ? developmentConstants : productionConstants);
+export default isDevelopment ? developmentConstants : productionConstants;

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -14,7 +14,10 @@ const commonConstants = {
     MAP_LAYERS_MIN_ZOOM_LEVEL: 15,
     NEW_OBJECT_TAG: 'new-',
     ADDRESS_GEOCODING_URL: 'https://api.digitransit.fi/geocoding/v1/search',
-    REVERSE_GEOCODING_URL: 'https://nominatim.openstreetmap.org/reverse',
+    STREET_NAME_REVERSE_GEOCODING_URL:
+        'https://nominatim.openstreetmap.org/reverse',
+    POSTAL_NUMBER_REVERSE_GEOCODING_URL:
+        'https://api.digitransit.fi/geocoding/v1/reverse',
     ADDRESS_SEARCH_RESULT_COUNT: 10
 };
 
@@ -36,4 +39,4 @@ const productionConstants = {
 
 const isDevelopment = process.env.NODE_ENV === 'development';
 
-export default isDevelopment ? developmentConstants : productionConstants;
+export default (isDevelopment ? developmentConstants : productionConstants);

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -14,7 +14,7 @@ const commonConstants = {
     MAP_LAYERS_MIN_ZOOM_LEVEL: 15,
     NEW_OBJECT_TAG: 'new-',
     ADDRESS_GEOCODING_URL: 'https://api.digitransit.fi/geocoding/v1/search',
-    REVERSE_GEOCODING_URL: 'https://api.digitransit.fi/geocoding/v1/reverse',
+    REVERSE_GEOCODING_URL: 'https://nominatim.openstreetmap.org/reverse',
     ADDRESS_SEARCH_RESULT_COUNT: 10
 };
 

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -4,11 +4,6 @@ import constants from '~/constants/constants';
 
 type langOptions = 'fi' | 'sv';
 
-interface IAddressData {
-    address: string;
-    postalNumber: string;
-}
-
 interface IAddressFeature {
     geometry: any;
     properties: any;
@@ -16,11 +11,15 @@ interface IAddressFeature {
 }
 
 class GeocodingService {
-    public static fetchAddressDataFromCoordinates = async (
+    public static fetchStreetNameFromCoordinates = async (
         coordinates: L.LatLng,
         lang: langOptions
-    ): Promise<IAddressData> => {
-        const requestUrl = `${constants.REVERSE_GEOCODING_URL}?lat=${coordinates.lat}&lon=${coordinates.lng}&format=geojson&accept-language=${lang}`;
+    ): Promise<string> => {
+        const requestUrl = `${
+            constants.STREET_NAME_REVERSE_GEOCODING_URL
+        }?lat=${coordinates.lat}&lon=${
+            coordinates.lng
+        }&format=geojson&accept-language=${lang}`;
 
         const response = await ApiClient.sendRequest(
             RequestMethod.GET,
@@ -35,16 +34,34 @@ class GeocodingService {
             response.features[0].properties &&
             response.features[0].properties.address
         ) {
-            const address = response.features[0].properties.address;
-            return {
-                address: address.road,
-                postalNumber: address.postcode
-            };
+            return response.features[0].properties.address.road;
         }
-        return {
-            address: '',
-            postalNumber: ''
-        };
+        return '';
+    };
+
+    public static fetchPostalNumberFromCoordinates = async (
+        coordinates: L.LatLng
+    ): Promise<string> => {
+        const requestUrl = `${
+            constants.POSTAL_NUMBER_REVERSE_GEOCODING_URL
+        }?point.lat=${coordinates.lat}&point.lon=${coordinates.lng}`;
+
+        const response = await ApiClient.sendRequest(
+            RequestMethod.GET,
+            encodeURI(requestUrl),
+            {}
+        );
+
+        if (
+            response &&
+            response.features &&
+            response.features[0] &&
+            response.features[0].properties &&
+            response.features[0].properties.postalcode
+        ) {
+            return response.features[0].properties.postalcode;
+        }
+        return '';
     };
 
     public static fetchAddressFeaturesFromString = async (
@@ -67,4 +84,4 @@ class GeocodingService {
 }
 export default GeocodingService;
 
-export { IAddressData, IAddressFeature };
+export { IAddressFeature };

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -1,0 +1,38 @@
+import * as L from 'leaflet';
+import ApiClient, { RequestMethod } from '~/util/ApiClient';
+
+const REVERSE_GEOCODING_URL = 'https://api.digitransit.fi/geocoding/v1/reverse';
+type langOptions = 'fi' | 'sv';
+
+interface AddressData {
+    address: string;
+    postalNumber: string;
+}
+
+class GeocodingService {
+    public static getAddressData = async (
+        coordinates: L.LatLng,
+        lang: langOptions
+    ): Promise<AddressData | null> => {
+        // API docs
+        // https://digitransit.fi/en/developers/apis/2-geocoding-api/address-lookup/
+        // oa = use OpenAddress layer
+        const requestUrl = `${REVERSE_GEOCODING_URL}?point.lat=${coordinates.lat}&point.lon=${coordinates.lng}&sources=oa&lang=${lang}`;
+
+        const response = await ApiClient.sendRequest(
+            RequestMethod.GET,
+            encodeURI(requestUrl),
+            {}
+        );
+
+        if (response && response.features && response.features[0]) {
+            const properties = response.features[0].properties;
+            return {
+                address: properties.name,
+                postalNumber: properties.postalcode
+            };
+        }
+        return null;
+    };
+}
+export default GeocodingService;

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -1,7 +1,7 @@
 import * as L from 'leaflet';
 import ApiClient, { RequestMethod } from '~/util/ApiClient';
+import constants from '~/constants/constants';
 
-const REVERSE_GEOCODING_URL = 'https://api.digitransit.fi/geocoding/v1/reverse';
 type langOptions = 'fi' | 'sv';
 
 interface AddressData {
@@ -13,11 +13,8 @@ class GeocodingService {
     public static getAddressData = async (
         coordinates: L.LatLng,
         lang: langOptions
-    ): Promise<AddressData | null> => {
-        // API docs
-        // https://digitransit.fi/en/developers/apis/2-geocoding-api/address-lookup/
-        // oa = use OpenAddress layer
-        const requestUrl = `${REVERSE_GEOCODING_URL}?point.lat=${coordinates.lat}&point.lon=${coordinates.lng}&sources=oa&lang=${lang}`;
+    ): Promise<AddressData> => {
+        const requestUrl = `${constants.REVERSE_GEOCODING_URL}?lat=${coordinates.lat}&lon=${coordinates.lng}&format=geojson&accept-language=${lang}`;
 
         const response = await ApiClient.sendRequest(
             RequestMethod.GET,
@@ -25,14 +22,23 @@ class GeocodingService {
             {}
         );
 
-        if (response && response.features && response.features[0]) {
-            const properties = response.features[0].properties;
+        if (
+            response &&
+            response.features &&
+            response.features[0] &&
+            response.features[0].properties &&
+            response.features[0].properties.address
+        ) {
+            const address = response.features[0].properties.address;
             return {
-                address: properties.name,
-                postalNumber: properties.postalcode
+                address: address.road,
+                postalNumber: address.postcode
             };
         }
-        return null;
+        return {
+            address: '',
+            postalNumber: ''
+        };
     };
 }
 export default GeocodingService;

--- a/src/services/geocodingService.ts
+++ b/src/services/geocodingService.ts
@@ -4,16 +4,22 @@ import constants from '~/constants/constants';
 
 type langOptions = 'fi' | 'sv';
 
-interface AddressData {
+interface IAddressData {
     address: string;
     postalNumber: string;
 }
 
+interface IAddressFeature {
+    geometry: any;
+    properties: any;
+    type: string;
+}
+
 class GeocodingService {
-    public static getAddressData = async (
+    public static fetchAddressDataFromCoordinates = async (
         coordinates: L.LatLng,
         lang: langOptions
-    ): Promise<AddressData> => {
+    ): Promise<IAddressData> => {
         const requestUrl = `${constants.REVERSE_GEOCODING_URL}?lat=${coordinates.lat}&lon=${coordinates.lng}&format=geojson&accept-language=${lang}`;
 
         const response = await ApiClient.sendRequest(
@@ -40,5 +46,25 @@ class GeocodingService {
             postalNumber: ''
         };
     };
+
+    public static fetchAddressFeaturesFromString = async (
+        value: string,
+        coordinates: L.LatLng
+    ): Promise<IAddressFeature[]> => {
+        const ADDRESS_GEOCODING_URL = constants.ADDRESS_GEOCODING_URL;
+        const SEARCH_RESULT_COUNT = constants.ADDRESS_SEARCH_RESULT_COUNT;
+        const lat = coordinates.lat;
+        const lng = coordinates.lng;
+        const requestUrl = `${ADDRESS_GEOCODING_URL}?text=${value}&size=${SEARCH_RESULT_COUNT}&focus.point.lat=${lat}&focus.point.lon=${lng}`;
+
+        const response = await ApiClient.sendRequest(
+            RequestMethod.GET,
+            encodeURI(requestUrl),
+            {}
+        );
+        return response.features;
+    };
 }
 export default GeocodingService;
+
+export { IAddressData, IAddressFeature };

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -8,7 +8,7 @@ import NodeStopFactory from '~/factories/nodeStopFactory';
 import GeometryUndoStore from '~/stores/geometryUndoStore';
 import { roundLatLng } from '~/util/geomHelper';
 import NodeMeasurementType from '~/enums/nodeMeasurementType';
-import GeocodingService, { IAddressData } from '~/services/geocodingService';
+import GeocodingService from '~/services/geocodingService';
 
 export interface UndoState {
     links: ILink[];
@@ -169,17 +169,20 @@ export class NodeStore {
         if (!this.node || !this.node.stop) return;
 
         const coordinates = this.node.coordinatesProjection;
-        const addressDataFi: IAddressData = await GeocodingService.fetchAddressDataFromCoordinates(
+        const addressFi: string = await GeocodingService.fetchStreetNameFromCoordinates(
             coordinates,
             'fi'
         );
-        const addressDataSw: IAddressData = await GeocodingService.fetchAddressDataFromCoordinates(
+        const addressSw: string = await GeocodingService.fetchStreetNameFromCoordinates(
             coordinates,
             'sv'
         );
-        this.updateStop('addressFi', addressDataFi.address);
-        this.updateStop('postalNumber', addressDataFi.postalNumber);
-        this.updateStop('addressSw', addressDataSw.address);
+        const postalNumber: string = await GeocodingService.fetchPostalNumberFromCoordinates(
+            coordinates
+        );
+        this.updateStop('addressFi', addressFi);
+        this.updateStop('addressSw', addressSw);
+        this.updateStop('postalNumber', postalNumber);
     };
 
     @action

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -8,7 +8,7 @@ import NodeStopFactory from '~/factories/nodeStopFactory';
 import GeometryUndoStore from '~/stores/geometryUndoStore';
 import { roundLatLng } from '~/util/geomHelper';
 import NodeMeasurementType from '~/enums/nodeMeasurementType';
-import GeocodingService from '~/services/geocodingService';
+import GeocodingService, { IAddressData } from '~/services/geocodingService';
 
 export interface UndoState {
     links: ILink[];
@@ -169,11 +169,11 @@ export class NodeStore {
         if (!this.node || !this.node.stop) return;
 
         const coordinates = this.node.coordinatesProjection;
-        const addressDataFi = await GeocodingService.getAddressData(
+        const addressDataFi: IAddressData = await GeocodingService.fetchAddressDataFromCoordinates(
             coordinates,
             'fi'
         );
-        const addressDataSw = await GeocodingService.getAddressData(
+        const addressDataSw: IAddressData = await GeocodingService.fetchAddressDataFromCoordinates(
             coordinates,
             'sv'
         );

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -20,6 +20,7 @@ export class NodeStore {
     @observable private _oldNode: INode | null;
     @observable private _oldLinks: ILink[];
     @observable private _isStopFormValid: boolean;
+    @observable private _isEditingDisabled: boolean;
     private _geometryUndoStore: GeometryUndoStore<UndoState>;
 
     constructor() {
@@ -28,6 +29,7 @@ export class NodeStore {
         this._oldNode = null;
         this._oldLinks = [];
         this._geometryUndoStore = new GeometryUndoStore();
+        this._isEditingDisabled = true;
     }
 
     @computed
@@ -51,6 +53,11 @@ export class NodeStore {
     @computed
     get isStopFormValid() {
         return this._isStopFormValid;
+    }
+
+    @computed
+    get isEditingDisabled() {
+        return this._isEditingDisabled;
     }
 
     @action
@@ -180,6 +187,16 @@ export class NodeStore {
     @action
     public setIsStopFormValid = (isStopFormValid: boolean) => {
         this._isStopFormValid = isStopFormValid;
+    };
+
+    @action
+    public setIsEditingDisabled = (isEditingDisabled: boolean) => {
+        this._isEditingDisabled = isEditingDisabled;
+    };
+
+    @action
+    public toggleIsEditingDisabled = () => {
+        this._isEditingDisabled = !this._isEditingDisabled;
     };
 
     @action

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -8,6 +8,7 @@ import NodeStopFactory from '~/factories/nodeStopFactory';
 import GeometryUndoStore from '~/stores/geometryUndoStore';
 import { roundLatLng } from '~/util/geomHelper';
 import NodeMeasurementType from '~/enums/nodeMeasurementType';
+import GeocodingService from '~/services/geocodingService';
 
 export interface UndoState {
     links: ILink[];
@@ -149,6 +150,10 @@ export class NodeStore {
         if (nodeLocationType === 'coordinates') {
             this.updateNode('measurementType', measurementType.toString());
         }
+
+        if (nodeLocationType === 'coordinatesProjection') {
+            this.fetchAddressData();
+        }
     };
 
     @action
@@ -157,6 +162,24 @@ export class NodeStore {
             node.coordinatesProjection = node.coordinates;
             node.coordinatesManual = node.coordinates;
         }
+    };
+
+    @action
+    public fetchAddressData = async () => {
+        if (!this.node || !this.node.stop) return;
+
+        const coordinates = this.node.coordinatesProjection;
+        const addressDataFi = await GeocodingService.getAddressData(
+            coordinates,
+            'fi'
+        );
+        const addressDataSw = await GeocodingService.getAddressData(
+            coordinates,
+            'sv'
+        );
+        this.updateStop('addressFi', addressDataFi.address);
+        this.updateStop('postalNumber', addressDataFi.postalNumber);
+        this.updateStop('addressSw', addressDataSw.address);
     };
 
     @action


### PR DESCRIPTION
* Implemented reverse geocoding using openstreetmap API: https://nominatim.org/release-docs/develop/api/Reverse/
* encountered a problem with current state of ViewFormBase: isEditingDisabled had to be moved to store.
    * also countered other problem: fetching address data in nodeStore -> need to validate stop properties in stop form -> had to implement 3 watch functions to stop form (addressFi, addressSw, postalNumber) to validate those fields changed by address fetch. Couldn't validate those properties in nodeStore (which would have been ideal solution), but instead had to listen changes to validate those properties in stop form because stop form has access to its invalidPropertiesMap
    -> this brought in mind an idea: what if viewFormBase would be in a store that each view would use. This one should be implemented in other card: https://github.com/HSLdevcom/jore-map-ui/issues/1019
* isEditingDisabled had to be moved to nodeStore because it was hard to watch when it changed to fetch address after that (however I could try to revert it back to viewFormBase since codebase changed slightly (address fetch is in nodeStore etc.)
    * refactoring task to move it out from VIewFromBase in other views as well: https://github.com/HSLdevcom/jore-map-ui/issues/1022
---

**Test this task carefully. Try to test every single variation. There are many ways that stop form could break.**

A few bugs fixed here:

Fixed stop form invalidPropertiesMap not reseting:
(test at stage environment)
1) open random stop form
2) change name of a stop to > 20 letters
3) click "isEditingDisabled"
-> error msg stays on screen

Fixed new stop form now validating properly
(test at stage environment)
1) open new stop form with "new stop tool"
2) change name field so that validation passes
3) create a new stop again
-> name field is not validated even though the field is empty