### PR TITLE
ApiClient now supports new error obj: { errorKey, keyValueMap }

### DIFF
--- a/src/codeLists/textCodeList.ts
+++ b/src/codeLists/textCodeList.ts
@@ -2,7 +2,13 @@ const textCodeList = {
     login_failed_no_jore_username:
         'Kirjautuminen epäonnistui, käyttäjänimeä ei löytynyt joukkoliikennerekisterin tietokannasta HSL-id:stä saadun sähköpostiosoitteen ${email} avulla.  Ota yhteyttä joukkoliikennerekisterin käyttäjätunnusten hallinnoijaan.',
     no_access_token:
-        'Kirjautuminen epäonnistui, HSL-id:stä ei antanut access tokenia.'
+        'Kirjautuminen epäonnistui, HSL-id:stä ei antanut access tokenia.',
+    validation_error:
+        'Tallennettavien tietojen validointi epäonnistui, Jore backendin antama virheviesti: ${errorMessage}',
+    node_creation_coordinates_out_of_bounds:
+        'Annettu geometria (lat ${lat}, lon ${lon}) on sallittujen rajojen (lat_min: ${lat_min} lat_max ${lat_max} lon_min ${lon_min} lon_max ${lon_max}) ulkopuolella.',
+    local_area_distribution_fetch_failed:
+        'Annetuilla koordinaateila (lat ${lat}, lon: ${lon}) ei löytynyt tietoja aluejako geojsonista solmun tunnuksen generointia varten.'
 };
 
 export default textCodeList;

--- a/src/util/ApiClient.ts
+++ b/src/util/ApiClient.ts
@@ -6,6 +6,7 @@ import AlertStore from '~/stores/alertStore';
 import httpStatusDescriptionCodeList from '~/codeLists/httpStatusDescriptionCodeList';
 import LoginStore from '~/stores/loginStore';
 import ApiClientHelper from './apiClientHelper';
+import CodeListHelper from './CodeListHelper';
 
 enum RequestMethod {
     GET = 'GET',
@@ -113,11 +114,24 @@ class ApiClient {
                     });
                 return;
             }
+            let responseJson;
+            try {
+                responseJson = JSON.parse(await response.text());
+            } catch {
+                responseJson = await response.text();
+            }
+            let errorMessage;
+            if (responseJson.errorKey) {
+                errorMessage = CodeListHelper.getText(
+                    responseJson.errorKey,
+                    responseJson.keyValueMap
+                );
+            } else {
+                errorMessage = responseJson
+                    ? responseJson
+                    : response.statusText;
+            }
 
-            const responseText = await response.text();
-            const errorMessage = responseText
-                ? responseText
-                : response.statusText;
             error = {
                 message: errorMessage,
                 name: 'Failed to fetch',

--- a/src/util/CodeListHelper.ts
+++ b/src/util/CodeListHelper.ts
@@ -2,7 +2,8 @@ import textCodeList from '~/codeLists/textCodeList';
 
 class CodeListHelper {
     /**
-     * @param {keyValueMap} { key: value } - key is the same as ${key} in textCodeListKey, ${key} is replaced with value
+     * @param {String} errorKey corresponding value needs to be declared in textCodeList
+     * @param {Object} keyValueMap { key: value } key is the same as ${key} in textCodeListKey, ${key} is replaced with value
      **/
     public static getText = (textCodeListKey: string, keyValueMap?: Object) => {
         let lineString = textCodeList[textCodeListKey];


### PR DESCRIPTION
Closes #913

Backend PR: https://gitlab.hsl.fi/jore/jore-map-backend/merge_requests/109

Now BE can send an error key + keyValueMap to display error messages in finnish

Examples to test different errors:

**To test validatorJS error:**

Insert into nodeService:

```
     import * as _ from 'lodash';
....
    public static updateNode = async (node: INode, links: ILink[]) => {
        const n = _.cloneDeep(node);
        n.stop!.nameFi = 'asdasfsafdasdsadsadsadsadasdsadsadsadsadsdsaasdsada';
        const requestBody: INodeSavingModel = {
            links,
            node: n
        };

        await ApiClient.updateObject(endpoints.NODE, requestBody);
        await apolloClient.clearStore();
    };
```

**To test geometry out of bounds error**
* create a new node, set stop location out of allowed bounds

**To test data not found from local area distribution**
* create a new node, set stop location in Baltic Sea