### PR TITLE
1022 node link opening fix

### DIFF
--- a/src/components/map/layers/edit/EditLinkLayer.tsx
+++ b/src/components/map/layers/edit/EditLinkLayer.tsx
@@ -161,11 +161,13 @@ class EditLinkLayer extends Component<IEditLinkLayerProps> {
         const link = this.props.linkStore!.link;
         return [
             <DashedLine
+                key={'startNodeDashedLine'}
                 startPoint={link.geometry[0]}
                 endPoint={link.startNode.coordinates}
                 color={'#efc210'}
             />,
             <DashedLine
+                key={'endNodeDashedLine'}
                 startPoint={link.geometry[link.geometry.length - 1]}
                 endPoint={link.endNode.coordinates}
                 color={'#efc210'}

--- a/src/components/map/layers/edit/EditRoutePathLayerLink.tsx
+++ b/src/components/map/layers/edit/EditRoutePathLayerLink.tsx
@@ -69,11 +69,13 @@ class EditRoutePathLayer extends Component<IRoutePathLayerProps> {
     private renderDashedLines = (routePathLink: IRoutePathLink) => {
         return [
             <DashedLine
+                key={'startNodeDashedLine'}
                 startPoint={routePathLink.geometry[0]}
                 endPoint={routePathLink.startNode.coordinates}
                 color={'#efc210'}
             />,
             <DashedLine
+                key={'endNodeDashedLine'}
                 startPoint={routePathLink.geometry[routePathLink.geometry.length - 1]}
                 endPoint={routePathLink.endNode.coordinates}
                 color={'#efc210'}

--- a/src/components/shared/inheritedComponents/ViewFormBase.tsx
+++ b/src/components/shared/inheritedComponents/ViewFormBase.tsx
@@ -1,5 +1,4 @@
 import { Component } from 'react';
-import EventManager from '~/util/EventManager';
 import FormValidator, { IValidationResult } from '~/validation/FormValidator';
 
 interface IViewFormBaseState {
@@ -12,16 +11,6 @@ interface IViewFormBaseState {
 // Inheritance is considered as a bad practice, react doesn't really support inheritance:
 // https://stackoverflow.com/questions/31072841/componentdidmount-method-not-triggered-when-using-inherited-es6-react-class
 class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Props, State> {
-    // TODO: remove
-    componentDidMount() {
-        EventManager.on('geometryChange', this.enableEditing);
-    }
-
-    // TODO: remove
-    componentWillUnmount() {
-        EventManager.off('geometryChange', this.enableEditing);
-    }
-
     private _validateUsingModel = (validationModel: object, validationEntity: any) => {
         Object.entries(validationModel).forEach(([property, validatorRule]) => {
             this.validateProperty(validatorRule, property, validationEntity[property]);
@@ -72,11 +61,6 @@ class ViewFormBase<Props, State extends IViewFormBaseState> extends Component<Pr
         this.setState({
             invalidPropertiesMap: {}
         });
-    };
-
-    // TODO: remove
-    protected enableEditing = () => {
-        this.setState({ isEditingDisabled: false });
     };
 }
 

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -51,12 +51,10 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
     }
 
     componentDidMount() {
-        super.componentDidMount();
         this.initialize();
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.lineStore!.clear();
     }
 

--- a/src/components/sidebar/lineView/lineHeaderView/LineHeaderView.tsx
+++ b/src/components/sidebar/lineView/lineHeaderView/LineHeaderView.tsx
@@ -52,7 +52,6 @@ class LineHeaderView extends ViewFormBase<ILineHeaderViewProps, ILineHeaderViewS
     }
 
     componentDidMount() {
-        super.componentDidMount();
         this.initialize();
     }
 
@@ -63,7 +62,6 @@ class LineHeaderView extends ViewFormBase<ILineHeaderViewProps, ILineHeaderViewS
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.lineHeaderStore!.clear();
     }
 

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import L from 'leaflet';
+import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
@@ -21,6 +22,7 @@ import { CodeListStore } from '~/stores/codeListStore';
 import { ErrorStore } from '~/stores/errorStore';
 import { LinkStore } from '~/stores/linkStore';
 import { MapStore } from '~/stores/mapStore';
+import EventManager from '~/util/EventManager';
 import { Button, Dropdown, TransitToggleButtonBar } from '../../controls';
 import InputContainer from '../../controls/InputContainer';
 import TextContainer from '../../controls/TextContainer';
@@ -38,26 +40,26 @@ interface ILinkViewProps extends RouteComponentProps<any> {
 
 interface ILinkViewState {
     isLoading: boolean;
-    isEditingDisabled: boolean;
+    isEditingDisabled: boolean; // TODO: remove
     invalidPropertiesMap: object;
 }
 
 @inject('linkStore', 'mapStore', 'errorStore', 'alertStore', 'codeListStore')
 @observer
 class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
+    private isEditingDisabledListener: IReactionDisposer;
     private existingTransitTypes: TransitType[] = [];
 
     constructor(props: ILinkViewProps) {
         super(props);
         this.state = {
             isLoading: false,
-            isEditingDisabled: !props.isNewLink,
+            isEditingDisabled: !props.isNewLink, // TODO: remove
             invalidPropertiesMap: {}
         };
     }
 
     async componentDidMount() {
-        super.componentDidMount();
         if (this.props.isNewLink) {
             await this.initNewLink();
         } else {
@@ -69,6 +71,12 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             this.props.mapStore!.setMapBounds(bounds);
             this.validateLink();
         }
+        this.setIsEditingDisabled(!this.props.isNewLink);
+        this.isEditingDisabledListener = reaction(
+            () => this.props.linkStore!.isEditingDisabled,
+            this.onChangeIsEditingDisabled
+        );
+        EventManager.on('geometryChange', () => this.setIsEditingDisabled(false));
     }
 
     componentDidUpdate(prevProps: ILinkViewProps) {
@@ -82,8 +90,9 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.linkStore!.clear();
+        this.isEditingDisabledListener();
+        EventManager.off('geometryChange', () => this.setIsEditingDisabled(false));
     }
 
     private initExistingLink = async () => {
@@ -162,6 +171,20 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         }
     };
 
+    private setIsEditingDisabled = (isEditingDisabled: boolean) => {
+        this.props.linkStore!.setIsEditingDisabled(isEditingDisabled);
+    };
+
+    private onChangeIsEditingDisabled = () => {
+        this.clearInvalidPropertiesMap();
+        const linkStore = this.props.linkStore;
+        if (linkStore!.isEditingDisabled) {
+            linkStore!.resetChanges();
+        } else {
+            this.validateLink();
+        }
+    };
+
     private navigateToNewLink = () => {
         const link = this.props.linkStore!.link;
         const linkViewLink = routeBuilder
@@ -177,18 +200,6 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             .toTarget(':id', nodeId)
             .toLink();
         navigator.goTo(editNetworkLink);
-    };
-
-    private toggleIsEditingEnabled = () => {
-        const linkStore = this.props.linkStore;
-        const isEditingDisabled = this.state.isEditingDisabled;
-        if (!isEditingDisabled) {
-            linkStore!.resetChanges();
-        } else {
-            linkStore!.updateLinkGeometry(linkStore!.link.geometry);
-            this.validateLink();
-        }
-        this.toggleIsEditingDisabled();
     };
 
     private validateLink = () => {
@@ -224,7 +235,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         // TODO: show some indicator to user of an empty page
         if (!link) return null;
 
-        const isEditingDisabled = this.state.isEditingDisabled;
+        const isEditingDisabled = this.props.linkStore!.isEditingDisabled;
         const startNode = link!.startNode;
         const endNode = link!.endNode;
 
@@ -232,7 +243,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
         const isSaveButtonDisabled =
             !transitType ||
-            this.state.isEditingDisabled ||
+            isEditingDisabled ||
             !this.props.linkStore!.isDirty ||
             (this.props.isNewLink && this.transitTypeAlreadyExists(transitType)) ||
             !this.isFormValid();
@@ -252,7 +263,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
                         isEditButtonVisible={!this.props.isNewLink}
                         isEditing={!isEditingDisabled}
                         shouldShowClosePromptMessage={this.props.linkStore!.isDirty!}
-                        onEditButtonClick={this.toggleIsEditingEnabled}
+                        onEditButtonClick={this.props.linkStore!.toggleIsEditingDisabled}
                     >
                         Linkki
                     </SidebarHeader>

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -71,12 +71,12 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             this.props.mapStore!.setMapBounds(bounds);
             this.validateLink();
         }
-        this.setIsEditingDisabled(!this.props.isNewLink);
+        this.props.linkStore!.setIsEditingDisabled(!this.props.isNewLink);
         this.isEditingDisabledListener = reaction(
             () => this.props.linkStore!.isEditingDisabled,
             this.onChangeIsEditingDisabled
         );
-        EventManager.on('geometryChange', () => this.setIsEditingDisabled(false));
+        EventManager.on('geometryChange', () => this.props.linkStore!.setIsEditingDisabled(false));
     }
 
     componentDidUpdate(prevProps: ILinkViewProps) {
@@ -92,7 +92,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
     componentWillUnmount() {
         this.props.linkStore!.clear();
         this.isEditingDisabledListener();
-        EventManager.off('geometryChange', () => this.setIsEditingDisabled(false));
+        EventManager.off('geometryChange', () => this.props.linkStore!.setIsEditingDisabled(false));
     }
 
     private initExistingLink = async () => {
@@ -168,11 +168,8 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             this.navigateToNewLink();
         } else {
             this.setState({ isLoading: false });
+            this.props.linkStore!.setIsEditingDisabled(true);
         }
-    };
-
-    private setIsEditingDisabled = (isEditingDisabled: boolean) => {
-        this.props.linkStore!.setIsEditingDisabled(isEditingDisabled);
     };
 
     private onChangeIsEditingDisabled = () => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -69,12 +69,12 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         } else {
             this.initExistingNode(params);
         }
-        this.setIsEditingDisabled(!this.props.isNewNode);
+        this.props.nodeStore!.setIsEditingDisabled(!this.props.isNewNode);
         this.isEditingDisabledListener = reaction(
             () => this.props.nodeStore!.isEditingDisabled,
             this.onChangeIsEditingDisabled
         );
-        EventManager.on('geometryChange', () => this.setIsEditingDisabled(false));
+        EventManager.on('geometryChange', () => this.props.nodeStore!.setIsEditingDisabled(false));
     }
 
     componentDidUpdate(prevProps: INodeViewProps) {
@@ -92,7 +92,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         this.props.nodeStore!.clear();
         this.props.mapStore!.setSelectedNodeId(null);
         this.isEditingDisabledListener();
-        EventManager.off('geometryChange', () => this.setIsEditingDisabled(false));
+        EventManager.off('geometryChange', () => this.props.nodeStore!.setIsEditingDisabled(false));
     }
 
     private initNewNode = async (params: any) => {
@@ -170,10 +170,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
         if (preventSetState) return;
         this.setState({ isLoading: false });
-    };
-
-    private setIsEditingDisabled = (isEditingDisabled: boolean) => {
-        this.props.nodeStore!.setIsEditingDisabled(isEditingDisabled);
+        this.props.nodeStore!.setIsEditingDisabled(true);
     };
 
     private onChangeIsEditingDisabled = () => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -63,7 +63,6 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
     }
 
     componentDidMount() {
-        super.componentDidMount();
         const params = this.props.match!.params.id;
         if (this.props.isNewNode) {
             this.initNewNode(params);
@@ -90,7 +89,6 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.nodeStore!.clear();
         this.props.mapStore!.setSelectedNodeId(null);
         this.isEditingDisabledListener();
@@ -178,10 +176,6 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         this.props.nodeStore!.setIsEditingDisabled(isEditingDisabled);
     };
 
-    private toggleIsEditingEnabled = () => {
-        this.props.nodeStore!.toggleIsEditingDisabled();
-    };
-
     private onChangeIsEditingDisabled = () => {
         this.clearInvalidPropertiesMap();
         if (this.props.nodeStore!.isEditingDisabled) {
@@ -257,7 +251,7 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
                         isEditButtonVisible={!this.props.isNewNode}
                         shouldShowClosePromptMessage={this.props.nodeStore!.isDirty}
                         isEditing={!isEditingDisabled}
-                        onEditButtonClick={this.toggleIsEditingEnabled}
+                        onEditButtonClick={this.props.nodeStore!.toggleIsEditingDisabled}
                     >
                         Solmu {node.id}
                     </SidebarHeader>

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -73,14 +73,12 @@ class RoutePathView extends ViewFormBase<IRoutePathViewProps, IRoutePathViewStat
     }
 
     componentDidMount() {
-        super.componentDidMount();
         EventManager.on('undo', this.props.routePathStore!.undo);
         EventManager.on('redo', this.props.routePathStore!.redo);
         this.initialize();
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.toolbarStore!.selectTool(null);
         this.props.networkStore!.setNodeSize(NodeSize.normal);
         this.props.routePathStore!.clear();

--- a/src/components/sidebar/routeView/RouteView.tsx
+++ b/src/components/sidebar/routeView/RouteView.tsx
@@ -52,12 +52,10 @@ class RouteView extends ViewFormBase<IRouteViewProps, IRouteViewState> {
     }
 
     componentDidMount() {
-        super.componentDidMount();
         this.initialize();
     }
 
     componentWillUnmount() {
-        super.componentWillUnmount();
         this.props.routeStore!.clear();
     }
 

--- a/src/components/sidebar/splitLinkView/SplitLinkView.tsx
+++ b/src/components/sidebar/splitLinkView/SplitLinkView.tsx
@@ -99,9 +99,8 @@ class SplitLinkView extends React.Component<ISplitLinkViewProps, ISplitLinkViewS
                     linkTransitType
                 );
                 const node = await NodeService.fetchNode(nodeId);
-                this.props.linkStore!.setLink(link);
                 this.props.linkStore!.setIsLinkGeometryEditable(false);
-                this.props.linkStore!.setNodes([node]);
+                this.props.linkStore!.init(link, [node]);
                 const bounds = L.latLngBounds(link.geometry);
                 bounds.extend(node.coordinates);
                 this.props.mapStore!.setMapBounds(bounds);

--- a/src/stores/geometryUndoStore.ts
+++ b/src/stores/geometryUndoStore.ts
@@ -8,6 +8,10 @@ class GeometryUndoStore<UndoObject> {
         this.clear();
     }
 
+    public getUndoObjectsLength = () => {
+        return this._undoObjects.length;
+    };
+
     public addItem = (undoObject: UndoObject) => {
         if (this._undoObjects.length !== 0) {
             EventManager.trigger('geometryChange');

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -60,10 +60,11 @@ export class NodeStore {
 
     @action
     public init = (node: INode, links: ILink[]) => {
+        this.clear();
+
         const newNode = _.cloneDeep(node);
         const newLinks = _.cloneDeep(links);
 
-        this.clear();
         const currentUndoState: UndoState = {
             links: newLinks,
             node: newNode
@@ -219,6 +220,7 @@ export class NodeStore {
         this._node = null;
         this._oldNode = null;
         this._geometryUndoStore.clear();
+        this._isEditingDisabled = true;
     };
 
     @action


### PR DESCRIPTION
Closes #1022 

Changes:
* Removed react warnings about missing key prop (dashed lines caused warnings)
* node form always opens in is editing disabled
* link form always opens in is editing disabled
* link editing undo bug fixed

Before testing, you can find those bugs in dev environment

link editing undo bug:
1) open a link
2) click edit pen TWICE
3) make two geometry changes
4) undo twice, it should return to the original position. Bug is, 3 undo's are required instead