### PR TITLE
NodeView: fetch & show available nodeIds shortId input field

### DIFF
--- a/src/components/controls/Dropdown.tsx
+++ b/src/components/controls/Dropdown.tsx
@@ -19,6 +19,7 @@ interface IDropdownProps {
     onChange: (value: any) => void;
     validationResult?: IValidationResult;
     darkerInputLabel?: boolean;
+    isDropdownOpen?: boolean;
 }
 
 interface IDropdownState {
@@ -156,6 +157,8 @@ class Dropdown extends React.Component<IDropdownProps, IDropdownState> {
                                 placeholder={'Valitse...'}
                                 styles={customStyles}
                                 noOptionsMessage={() => 'Ei hakutuloksia'}
+                                menuIsOpen={this.props.isDropdownOpen}
+                                autoFocus={this.props.isDropdownOpen}
                             />
                             <div>
                                 {validationResult &&

--- a/src/components/sidebar/nodeView/ShortIdInput.tsx
+++ b/src/components/sidebar/nodeView/ShortIdInput.tsx
@@ -1,0 +1,164 @@
+import classnames from 'classnames';
+import { reaction, IReactionDisposer } from 'mobx';
+import { inject, observer } from 'mobx-react';
+import React from 'react';
+import { Button } from '~/components/controls';
+import Dropdown, { IDropdownItem } from '~/components/controls/Dropdown';
+import InputContainer from '~/components/controls/InputContainer';
+import ButtonType from '~/enums/buttonType';
+import { INode } from '~/models';
+import StopService from '~/services/stopService';
+import { NodeStore } from '~/stores/nodeStore';
+import * as s from './shortIdInput.scss';
+
+interface IStopFormProps {
+    node: INode;
+    isEditingDisabled: boolean;
+    nodeInvalidPropertiesMap: object;
+    nodeStore?: NodeStore;
+    onNodePropertyChange: (property: keyof INode) => (value: any) => void;
+}
+
+interface IStopFormState {
+    availableShortIds: string[];
+    availableShortIdDropdownItems: IDropdownItem[];
+    isAvailableShortIdsDropdownVisible: boolean;
+}
+
+@inject('nodeStore')
+@observer
+class ShortIdInput extends React.Component<IStopFormProps, IStopFormState> {
+    private mounted: boolean;
+    private isShortIdLetterListener: IReactionDisposer;
+
+    constructor(props: IStopFormProps) {
+        super(props);
+        this.state = {
+            availableShortIds: [],
+            availableShortIdDropdownItems: [],
+            isAvailableShortIdsDropdownVisible: false
+        };
+    }
+
+    componentDidMount() {
+        this.mounted = true;
+        this.isShortIdLetterListener = reaction(
+            () => this.props.nodeStore!.node.shortIdLetter,
+            this.fetchAvailableShortIds
+        );
+        this.fetchAvailableShortIds();
+    }
+
+    componentWillUnmount() {
+        this.mounted = false;
+        this.isShortIdLetterListener();
+    }
+
+    private fetchAvailableShortIds = async () => {
+        const shortIdLetter = this.props.nodeStore!.node.shortIdLetter;
+        const availableShortIds: string[] = await StopService.fetchAvailableShortIds(shortIdLetter);
+        if (this.mounted) {
+            this.setState({
+                availableShortIds,
+                availableShortIdDropdownItems: this.createAvailableShortIdDropdownItems(
+                    availableShortIds
+                )
+            });
+        }
+    };
+
+    private createAvailableShortIdDropdownItems = (
+        availableShortIds: string[]
+    ): IDropdownItem[] => {
+        return availableShortIds.map((shortId: string) => {
+            const item: IDropdownItem = {
+                value: `${shortId}`,
+                label: `${shortId}`
+            };
+            return item;
+        });
+    };
+
+    private onNodeShortIdChange = (value: string) => {
+        this.setState({
+            isAvailableShortIdsDropdownVisible: false
+        });
+        this.props.onNodePropertyChange('shortIdString')(value);
+    };
+
+    private renderToggleDropdownButton = () => {
+        const text = this.state.isAvailableShortIdsDropdownVisible ? 'X' : 'Hae';
+        return (
+            <Button
+                onClick={() => this.toggleDropdownVisibility()}
+                type={ButtonType.SQUARE}
+                className={classnames(
+                    s.shortIdInputButton,
+                    this.state.isAvailableShortIdsDropdownVisible ? s.redBackground : null
+                )}
+            >
+                {text}
+            </Button>
+        );
+    };
+
+    private toggleDropdownVisibility = () => {
+        this.setState({
+            isAvailableShortIdsDropdownVisible: !this.state.isAvailableShortIdsDropdownVisible
+        });
+    };
+
+    private renderValidationNotification = () => {
+        const validationResult = this.props.nodeInvalidPropertiesMap['shortIdString'];
+        if (this.props.isEditingDisabled || validationResult.errorMessage) return null;
+        const selectedShortId = this.props.node.shortIdString;
+        if (!selectedShortId) return null;
+        if (!this.props.nodeStore!.isShortIdDirty) return null;
+
+        const isAvailable = this.state.availableShortIds.includes(selectedShortId);
+        return isAvailable ? (
+            <div className={s.isValidMessage}>Lyhyttunnus on vapaa</div>
+        ) : (
+            <div className={s.warningMessage}>Lyhyttunnus on jo käytössä</div>
+        );
+    };
+
+    render() {
+        const isEditingDisabled = this.props.nodeStore!.isEditingDisabled;
+        const node = this.props.node;
+        const shortIdLabel = '+ 4 num.)';
+        return (
+            <div className={s.shortIdInputView}>
+                <div className={s.shortIdInputContainer}>
+                    {this.state.isAvailableShortIdsDropdownVisible ? (
+                        <Dropdown
+                            label={shortIdLabel}
+                            onChange={this.onNodeShortIdChange}
+                            items={this.state.availableShortIdDropdownItems}
+                            selected={node.shortIdString}
+                            emptyItem={{
+                                value: '',
+                                label: ''
+                            }}
+                            disabled={isEditingDisabled}
+                            validationResult={this.props.nodeInvalidPropertiesMap['shortIdString']}
+                            isDropdownOpen={true}
+                        />
+                    ) : (
+                        <InputContainer
+                            label={shortIdLabel}
+                            onChange={this.onNodeShortIdChange}
+                            disabled={isEditingDisabled}
+                            value={node.shortIdString}
+                            validationResult={this.props.nodeInvalidPropertiesMap['shortIdString']}
+                        />
+                    )}
+                    {!isEditingDisabled && this.renderToggleDropdownButton()}
+                </div>
+                <div>{this.renderValidationNotification()}</div>
+            </div>
+        );
+    }
+}
+
+export default ShortIdInput;

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -14,6 +14,7 @@ import StopService, { IStopAreaItem, IStopSectionItem } from '~/services/stopSer
 import { CodeListStore } from '~/stores/codeListStore';
 import { NodeStore } from '~/stores/nodeStore';
 import SidebarHeader from '../SidebarHeader';
+import ShortIdInput from './ShortIdInput';
 import * as s from './stopForm.scss';
 
 interface IStopFormProps {
@@ -54,7 +55,18 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
         this.stopPropertyListeners = [];
     }
 
-    async componentWillMount() {
+    async componentDidMount() {
+        this.mounted = true;
+        this.validateStop();
+        this.isEditingDisabledListener = reaction(
+            () => this.props.nodeStore!.isEditingDisabled,
+            this.onChangeIsEditingDisabled
+        );
+        this.nodeListener = reaction(() => this.props.nodeStore!.node, this.onNodeChange);
+        this.createStopPropertyListeners();
+        if (this.props.isNewStop) {
+            this.props.nodeStore!.fetchAddressData();
+        }
         const stopAreas: IStopAreaItem[] = await StopService.fetchAllStopAreas();
         const stopSections: IStopSectionItem[] = await StopService.fetchAllStopSections();
         if (this.mounted) {
@@ -63,20 +75,6 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
                 stopSections: this.createStopSectionDropdownItems(stopSections)
             });
         }
-    }
-
-    componentDidMount() {
-        this.mounted = true;
-        this.validateStop();
-        if (this.props.isNewStop) {
-            this.props.nodeStore!.fetchAddressData();
-        }
-        this.isEditingDisabledListener = reaction(
-            () => this.props.nodeStore!.isEditingDisabled,
-            this.onChangeIsEditingDisabled
-        );
-        this.nodeListener = reaction(() => this.props.nodeStore!.node, this.onNodeChange);
-        this.createStopPropertyListeners();
     }
 
     componentWillUnmount() {
@@ -216,12 +214,11 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
                             }}
                             items={this.getShortIdLetterItems()}
                         />
-                        <InputContainer
-                            label='+ 4 num.)'
-                            disabled={isEditingDisabled}
-                            value={node.shortIdString}
-                            onChange={this.props.onNodePropertyChange('shortIdString')}
-                            validationResult={this.props.nodeInvalidPropertiesMap['shortIdString']}
+                        <ShortIdInput
+                            node={node}
+                            isEditingDisabled={isEditingDisabled}
+                            nodeInvalidPropertiesMap={this.props.nodeInvalidPropertiesMap}
+                            onNodePropertyChange={this.props.onNodePropertyChange}
                         />
                     </div>
                 </div>

--- a/src/components/sidebar/nodeView/shortIdInput.scss
+++ b/src/components/sidebar/nodeView/shortIdInput.scss
@@ -1,0 +1,38 @@
+@import '../../shared/styles/common.scss';
+@import '../../shared/styles/flexbox';
+@import '../../shared/styles/form';
+
+.shortIdInputView {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    .shortIdInputContainer {
+        display: flex;
+        width: 100%;
+
+        .shortIdInputButton {
+            margin-top: 30px;
+            margin-bottom: auto;
+            width: 30px;
+        }
+
+        & .redBackground {
+            background-color: $red;
+        }
+
+        & .redBackground:hover {
+            background-color: darken($red, 10);
+        }
+    }
+
+    .warningMessage {
+        color: $warningYellow;
+        font-size: 12px;
+    }
+
+    .isValidMessage {
+        color: $successGreen;
+        font-size: 12px;
+    }
+}

--- a/src/factories/nodeFactory.ts
+++ b/src/factories/nodeFactory.ts
@@ -46,8 +46,6 @@ class NodeFactory {
 
     public static createNodeBase = (externalNode: IExternalNode): INodeBase => {
         const type = getNodeType(externalNode.soltyyppi, externalNode.soltunnus);
-        // TODO: Change this when creating abstraction layers for reading from postgis
-
         return {
             type,
             shortIdLetter: externalNode.solkirjain,

--- a/src/models/validationModels/nodeValidationModel.ts
+++ b/src/models/validationModels/nodeValidationModel.ts
@@ -7,7 +7,7 @@ type INodeValidationModel = { [key in NodeKeys]: string };
 const nodeValidationModel: INodeValidationModel = {
     id: '',
     type: 'required|min:1|max:1|string',
-    shortIdString: `min:0|max:4|string|${regexRules.numbers}`,
+    shortIdString: `min:4|max:4|string|${regexRules.numbers}`,
     tripTimePoint: 'min:0|max:1|string',
     modifiedBy: '',
     modifiedOn: '',

--- a/src/services/__tests__/stopService.test.ts
+++ b/src/services/__tests__/stopService.test.ts
@@ -1,0 +1,93 @@
+import ApolloClient from '~/util/ApolloClient';
+import StopService from '../stopService';
+
+jest.mock('../../util/ApolloClient');
+
+// These tests expect that StopService.SHORT_ID_LENGTH = 4
+
+describe('StopService.fetchAvailableShortIds', () => {
+    it('Works without letting currentNode affect reservedShortIds if no nodeId match found', async () => {
+        const queryReturnValue = {
+            data: {
+                getReservedShortIds: {
+                    nodes: [
+                        {
+                            soltunnus: '1',
+                            sollistunnus: '0001'
+                        },
+                        {
+                            soltunnus: '2',
+                            sollistunnus: '0002'
+                        }
+                    ]
+                }
+            }
+        };
+        ApolloClient.query = jest.fn(async (options: any) => queryReturnValue);
+        const currentNodeId = '3';
+
+        const availableIds = await StopService.fetchAvailableShortIds(currentNodeId);
+        expect(availableIds.includes('0000')).toEqual(true);
+        expect(availableIds.includes('0001')).toEqual(false);
+        expect(availableIds.includes('0002')).toEqual(false);
+        expect(availableIds.includes('0003')).toEqual(true);
+    });
+
+    it('Removes shortId of the currentNode from availableIds', async () => {
+        const queryReturnValue = {
+            data: {
+                getReservedShortIds: {
+                    nodes: [
+                        {
+                            soltunnus: '1',
+                            sollistunnus: '0001'
+                        },
+                        {
+                            soltunnus: '2',
+                            sollistunnus: '0002'
+                        }
+                    ]
+                }
+            }
+        };
+        ApolloClient.query = jest.fn(async (options: any) => queryReturnValue);
+        const currentNodeId = '1';
+
+        const availableIds = await StopService.fetchAvailableShortIds(currentNodeId);
+        expect(availableIds.includes('0000')).toEqual(true);
+        expect(availableIds.includes('0001')).toEqual(true);
+        expect(availableIds.includes('0002')).toEqual(false);
+        expect(availableIds.includes('0003')).toEqual(true);
+    });
+
+    it('Doesnt remove shortId of the currentNode from availableIds if more than 2 shortIds match shortId of the currentNode', async () => {
+        const queryReturnValue = {
+            data: {
+                getReservedShortIds: {
+                    nodes: [
+                        {
+                            soltunnus: '1',
+                            sollistunnus: '0001'
+                        },
+                        {
+                            soltunnus: '2',
+                            sollistunnus: '0001'
+                        },
+                        {
+                            soltunnus: '3',
+                            sollistunnus: '0002'
+                        }
+                    ]
+                }
+            }
+        };
+        ApolloClient.query = jest.fn(async (options: any) => queryReturnValue);
+        const currentNodeId = '1';
+
+        const availableIds = await StopService.fetchAvailableShortIds(currentNodeId);
+        expect(availableIds.includes('0000')).toEqual(true);
+        expect(availableIds.includes('0001')).toEqual(false);
+        expect(availableIds.includes('0002')).toEqual(false);
+        expect(availableIds.includes('0003')).toEqual(true);
+    });
+});

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -238,6 +238,7 @@ const getReservedShortIds = () => {
         query getReservedShortIds($shortIdLetter: String) {
             getReservedShortIds: allSolmus(condition: { solkirjain: $shortIdLetter }) {
                 nodes {
+                    soltunnus
                     sollistunnus
                 }
             }

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -92,7 +92,7 @@ const getRoutePathLinkQuery = () => {
 
 const getRoutePathSegmentQuery = () => {
     return gql`query getRoutePathLinksFromRoutePathSegment($startNodeId: String, $endNodeId: String, $transitType: String) {
-            linkswithroutepathinfo: getRoutePathLinksFromRoutePathSegment(startnodeid: $startNodeId, endnodeid: $endNodeId, transittype: $transitType) {
+        linkswithroutepathinfo: getRoutePathLinksFromRoutePathSegment(startnodeid: $startNodeId, endnodeid: $endNodeId, transittype: $transitType) {
                 nodes {
                     ${routePathSegmentQueryFields}
                 }
@@ -227,6 +227,18 @@ const getAllStopSections = () => {
             node: allVyohykes {
                 nodes {
                     selite
+                }
+            }
+        }
+    `;
+};
+
+const getReservedShortIds = () => {
+    return gql`
+        query getReservedShortIds($shortIdLetter: String) {
+            getReservedShortIds: allSolmus(condition: { solkirjain: $shortIdLetter }) {
+                nodes {
+                    sollistunnus
                 }
             }
         }
@@ -568,5 +580,6 @@ export default {
     getLineHeaderQuery,
     getAllLineHeadersQuery,
     getAllStopSections,
+    getReservedShortIds,
     getViaName
 };

--- a/src/services/stopService.ts
+++ b/src/services/stopService.ts
@@ -18,6 +18,8 @@ interface IReservedShortIdItem {
     shortId: string;
 }
 
+const SHORT_ID_LENGTH = 4;
+
 class StopService {
     // Expose function for testing
     public static fetchAllStopAreas = async (): Promise<IStopAreaItem[]> => {
@@ -36,9 +38,10 @@ class StopService {
         return queryResult.data.node.nodes;
     };
 
-    public static fetchReservedShortIds = async (
+    public static fetchAvailableShortIds = async (
+        currentNodeId: string,
         shortIdLetter?: string
-    ): Promise<IReservedShortIdItem[]> => {
+    ): Promise<string[]> => {
         const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
             query: GraphqlQueries.getReservedShortIds(),
             variables: {
@@ -57,10 +60,46 @@ class StopService {
                 };
             })
             .value();
-        return reservedShortIds;
+        const availableShortIds: string[] = _getAvailableShortIds(reservedShortIds, currentNodeId);
+        return availableShortIds;
     };
 }
 
+const _getAvailableShortIds = (
+    reservedShortIdItems: IReservedShortIdItem[],
+    currentNodeId: string
+): string[] => {
+    const allShortIdVariations = _generateAllShortIdVariations(SHORT_ID_LENGTH);
+    return allShortIdVariations.filter(
+        shortIdVariation =>
+            !reservedShortIdItems.find((reservedShortIdItem: IReservedShortIdItem) => {
+                return (
+                    reservedShortIdItem.shortId === shortIdVariation &&
+                    // Prevent currently opened node to affect available ids
+                    reservedShortIdItem.nodeId !== currentNodeId
+                );
+            })
+    );
+};
+
+/**
+ * @param numberCount - e.g. with numberCount 4, generates ["0000", "0001", "0002", ..., "9998", "9999"]
+ **/
+const _generateAllShortIdVariations = (numberCount: number) => {
+    const allNumbers: string[] = [];
+    let max = '';
+    for (let i = 0; i < numberCount; i += 1) {
+        max += '9';
+    }
+    for (let i = 0; i <= parseInt(max, 10); i += 1) {
+        const current = String(i);
+        const missingZeroCount = numberCount - current.length;
+        const missingZeros = '0'.repeat(missingZeroCount);
+        allNumbers.push(missingZeros + current);
+    }
+    return allNumbers;
+};
+
 export default StopService;
 
-export { IStopAreaItem, IStopSectionItem, IReservedShortIdItem };
+export { IStopAreaItem, IStopSectionItem };

--- a/src/services/stopService.ts
+++ b/src/services/stopService.ts
@@ -1,4 +1,6 @@
 import { ApolloQueryResult } from 'apollo-client';
+import _ from 'lodash';
+import IExternalNode from '~/models/externals/IExternalNode';
 import ApolloClient from '~/util/ApolloClient';
 import GraphqlQueries from './graphqlQueries';
 
@@ -27,7 +29,41 @@ class StopService {
 
         return queryResult.data.node.nodes;
     };
+
+    public static fetchAvailableShortIds = async (shortIdLetter?: string): Promise<string[]> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getReservedShortIds(),
+            variables: {
+                shortIdLetter
+            }
+        });
+        const reservedShortIds = _.chain(queryResult.data.getReservedShortIds.nodes)
+            .filter(node => node !== null)
+            .map((node: IExternalNode) => node.sollistunnus)
+            .uniq()
+            .value();
+        const allNumberVariations = _generateAllNumberVariations(4);
+        return allNumberVariations.filter(num => !reservedShortIds.includes(num));
+    };
 }
+
+/**
+ * @param numberCount - e.g. with numberCount 4, generates ["0000", "0001", "0002", ..., "9998", "9999"]
+ **/
+const _generateAllNumberVariations = (numberCount: number) => {
+    const allNumbers: string[] = [];
+    let max = '';
+    for (let i = 0; i < numberCount; i += 1) {
+        max += '9';
+    }
+    for (let i = 0; i <= parseInt(max, 10); i += 1) {
+        const current = String(i);
+        const missingZeroCount = numberCount - current.length;
+        const missingZeros = '0'.repeat(missingZeroCount);
+        allNumbers.push(missingZeros + current);
+    }
+    return allNumbers;
+};
 
 export default StopService;
 

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -49,11 +49,6 @@ export class NodeStore {
     }
 
     @computed
-    get isShortIdDirty() {
-        return this._node!.shortIdString !== this._oldNode!.shortIdString;
-    }
-
-    @computed
     get isStopFormValid() {
         return this._isStopFormValid;
     }

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -49,6 +49,11 @@ export class NodeStore {
     }
 
     @computed
+    get isShortIdDirty() {
+        return this._node!.shortIdString !== this._oldNode!.shortIdString;
+    }
+
+    @computed
     get isStopFormValid() {
         return this._isStopFormValid;
     }


### PR DESCRIPTION
Closes #773 

* Moved calling fetch at stopForm componentWillMount -> componentDidMount

Now user can search for available short ids for a shortIdLetter
* the search functionality is bad (idd). With quick googling I couldn't find solution to support jokers (*) in search. We can add that functionality later.

Remember to test:

case 1:
* Node X has shortLetter H shortIdLetter shortIdString 6666 (this should be saved value)
* Open node X
* there is no other node with shortLetter H shortIdString 6666 combination
* Selecting H + 6666 again doesn't show "Lyhyttunnus on vapaa" (because shortIdString is dirty)

case 2:
* H 6666 is reserved for node X
* E 6666 is free
* open node Y
* put H 6666, should show "lyhyttunnus varattu"
* put E 6666, should show "lyhyttunnus on vapaa"