### PR TITLE
Fixed link init & geometry bugs

### DIFF
--- a/src/factories/linkFactory.ts
+++ b/src/factories/linkFactory.ts
@@ -24,7 +24,7 @@ class LinkFactory {
     };
 
     public static createNewLink = (startNode: INode, endNode: INode): ILink => {
-        const geometry = [startNode.coordinates, endNode.coordinates];
+        const geometry = [startNode.coordinatesProjection, endNode.coordinatesProjection];
         return {
             geometry,
             startNode,

--- a/src/util/__tests__/leafletUtils.test.ts
+++ b/src/util/__tests__/leafletUtils.test.ts
@@ -2,7 +2,7 @@ import { LatLng } from 'leaflet';
 import LeafletUtils from '../leafletUtils';
 
 describe('leafletUtils.calculateLengthFromLatLngs', () => {
-    it('Calculates length between two points', () => {
+    it('Calculates length between two points - round down', () => {
         const positions: LatLng[] = [
             new LatLng(60.165958, 24.9436),
             new LatLng(60.199303, 24.940759)
@@ -11,6 +11,18 @@ describe('leafletUtils.calculateLengthFromLatLngs', () => {
         // https://gps-coordinates.org/distance-between-coordinates.php
         // calculated distance to 3711.12 meters, rounds to 3711
         const expectedLength = 3711;
+        expect(LeafletUtils.calculateLengthFromLatLngs(positions)).toEqual(expectedLength);
+    });
+
+    it('Calculates length between two points - round up', () => {
+        const positions: LatLng[] = [
+            new LatLng(60.17520298, 24.91285215),
+            new LatLng(60.1745068, 24.91877853)
+        ];
+
+        // https://gps-coordinates.org/distance-between-coordinates.php
+        // calculated distance to 336.77 meters, rounds to 337
+        const expectedLength = 337;
         expect(LeafletUtils.calculateLengthFromLatLngs(positions)).toEqual(expectedLength);
     });
 });

--- a/src/util/leafletUtils.ts
+++ b/src/util/leafletUtils.ts
@@ -22,6 +22,7 @@ const createDivIcon = (html: any, options: IDivIconOptions = {}) => {
     return new L.DivIcon(divIconOptions);
 };
 
+// TODO: move to geomHelpers
 const calculateLengthFromLatLngs = (latLngs: L.LatLng[]) => {
     let length = 0;
     latLngs.forEach((latLng, index) => {
@@ -31,7 +32,4 @@ const calculateLengthFromLatLngs = (latLngs: L.LatLng[]) => {
     return Math.round(length);
 };
 
-export default {
-    createDivIcon,
-    calculateLengthFromLatLngs
-};
+export default { createDivIcon, calculateLengthFromLatLngs };


### PR DESCRIPTION
Closes #1036 

BE PR: https://gitlab.hsl.fi/jore/jore-map-backend/merge_requests/134

* Link's automatic geometry length is now calculated in linkStore init.
    * to test this, open a link that you think changes length when calculated automatically, then click edit pen -> save button active (because length has been updated)

* Fixed some bugs in linkStore

* Fixed critical bug where created link used wrong coordinate pair