### PR TITLE
StopAreaView init

### DIFF
--- a/src/components/overlays/SavePrompt.tsx
+++ b/src/components/overlays/SavePrompt.tsx
@@ -43,6 +43,7 @@ const renderChangeRow = (oldValue: string, newValue: string) => {
     );
 };
 
+// TODO: move to shared folder. This isn't really an overlay
 const SavePrompt = observer((props: ISavePromptProps) => {
     const newLink = _.cloneDeep(props.newData);
     const oldLink = _.cloneDeep(props.oldData);

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -56,7 +56,7 @@ class Sidebar extends React.Component<ISidebarProps, ILinelistState> {
     private renderNewNodeView = (props: any) => <NodeView {...props} isNewNode={true} />;
     private renderNodeView = (props: any) => <NodeView {...props} isNewNode={false} />;
     private renderNewStopAreaView = (props: any) => {
-        return <StopAreaView {...props} />;
+        return <StopAreaView {...props} isNewStopArea={true} />;
     };
     private renderStopAreaView = (props: any) => <StopAreaView {...props} isNewStopArea={false} />;
     private renderNewLinkView = (props: any) => <LinkView {...props} isNewLink={true} />;

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import LineView from './lineView/LineView';
 import LineHeaderView from './lineView/lineHeaderView/LineHeaderView';
 import LinkView from './linkView/LinkView';
 import NodeView from './nodeView/NodeView';
+import StopAreaView from './nodeView/StopAreaView';
 import RouteListView from './routeListView/RouteListView';
 import RoutePathView from './routePathView/RoutePathView';
 import RouteView from './routeView/RouteView';
@@ -54,6 +55,10 @@ class Sidebar extends React.Component<ISidebarProps, ILinelistState> {
     private renderRouteView = (props: any) => <RouteView {...props} isNewRoute={false} />;
     private renderNewNodeView = (props: any) => <NodeView {...props} isNewNode={true} />;
     private renderNodeView = (props: any) => <NodeView {...props} isNewNode={false} />;
+    private renderNewStopAreaView = (props: any) => {
+        return <StopAreaView {...props} />;
+    };
+    private renderStopAreaView = (props: any) => <StopAreaView {...props} isNewStopArea={false} />;
     private renderNewLinkView = (props: any) => <LinkView {...props} isNewLink={true} />;
     private renderLinkView = (props: any) => <LinkView {...props} isNewLink={false} />;
     private renderNewRoutePathView = (props: any) => (
@@ -97,6 +102,22 @@ class Sidebar extends React.Component<ISidebarProps, ILinelistState> {
                         />
                         <Route
                             exact={true}
+                            path={subSites.newNode}
+                            component={this.renderNewNodeView}
+                        />
+                        <Route exact={true} path={subSites.node} component={this.renderNodeView} />
+                        <Route
+                            exact={true}
+                            path={subSites.newStopArea}
+                            component={this.renderNewStopAreaView}
+                        />
+                        <Route
+                            exact={true}
+                            path={subSites.stopArea}
+                            component={this.renderStopAreaView}
+                        />
+                        <Route
+                            exact={true}
                             path={subSites.routes}
                             component={this.renderRouteListView}
                         />
@@ -107,12 +128,6 @@ class Sidebar extends React.Component<ISidebarProps, ILinelistState> {
                         />
                         <Route exact={true} path={subSites.link} component={this.renderLinkView} />
                         <Route exact={true} path={subSites.splitLink} component={SplitLinkView} />
-                        <Route
-                            exact={true}
-                            path={subSites.newNode}
-                            component={this.renderNewNodeView}
-                        />
-                        <Route exact={true} path={subSites.node} component={this.renderNodeView} />
                         <Route
                             exact={true}
                             path={subSites.newRoutePath}

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -97,10 +97,6 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
     };
 
     private initExistingLine = async () => {
-        await this.fetchLine();
-    };
-
-    private fetchLine = async () => {
         const lineId = this.props.match!.params.id;
         try {
             const line = await LineService.fetchLine(lineId);

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -155,11 +155,9 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
     private save = async () => {
         this.setState({ isLoading: true });
-        let shouldNavigateToNewLink = false;
         try {
             if (this.props.isNewLink) {
                 await LinkService.createLink(this.props.linkStore!.link);
-                shouldNavigateToNewLink = true;
             } else {
                 await LinkService.updateLink(this.props.linkStore!.link);
                 this.props.linkStore!.setOldLink(this.props.linkStore!.link);
@@ -169,12 +167,12 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             this.props.errorStore!.addError(`Tallennus epäonnistui`, e);
         }
 
-        if (shouldNavigateToNewLink) {
+        if (this.props.isNewLink) {
             this.navigateToNewLink();
-        } else {
-            this.setState({ isLoading: false });
-            this.props.linkStore!.setIsEditingDisabled(true);
+            return;
         }
+        this.setState({ isLoading: false });
+        this.props.linkStore!.setIsEditingDisabled(true);
     };
 
     private showSavePrompt = () => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -109,9 +109,11 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         }
     };
 
+    // TODO: rename as nodePropertyListener
     private createListener = (property: string) => {
         return reaction(
             () => this.props.nodeStore!.node && this.props.nodeStore!.node![property],
+            // TODO: this should validate node[propety] instead of all node properties
             this.validateNode
         );
     };

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -103,18 +103,16 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
         const node = nodeStore!.node;
         for (const property in node!) {
             if (Object.prototype.hasOwnProperty.call(node, property)) {
-                const listener = this.createListener(property);
+                const listener = this.nodePropertyListener(property);
                 this.nodePropertyListeners.push(listener);
             }
         }
     };
 
-    // TODO: rename as nodePropertyListener
-    private createListener = (property: string) => {
+    private nodePropertyListener = (property: string) => {
         return reaction(
             () => this.props.nodeStore!.node && this.props.nodeStore!.node![property],
-            // TODO: this should validate node[propety] instead of all node properties
-            this.validateNode
+            this.validateNodeProperty(property)
         );
     };
 
@@ -210,6 +208,14 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private validateNode = () => {
         this.validateAllProperties(nodeValidationModel, this.props.nodeStore!.node);
+    };
+
+    private validateNodeProperty = (property: string) => () => {
+        const node = this.props.nodeStore!.node;
+        if (!node) return;
+
+        const value = node[property];
+        this.validateProperty(nodeValidationModel[property], property, value);
     };
 
     private onNodeGeometryChange = (property: NodeLocationType, value: any) => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -172,12 +172,9 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
 
     private save = async () => {
         this.setState({ isLoading: true });
-        let preventSetState = false;
         try {
             if (this.props.isNewNode) {
                 const nodeId = await NodeService.createNode(this.props.nodeStore!.node);
-                preventSetState = true;
-
                 const url = routeBuilder
                     .to(SubSites.node)
                     .toTarget(':id', nodeId)
@@ -189,14 +186,13 @@ class NodeView extends ViewFormBase<INodeViewProps, INodeViewState> {
                     this.props.nodeStore!.getDirtyLinks()
                 );
             }
-
             this.props.nodeStore!.setCurrentStateAsOld();
             this.props.alertStore!.setFadeMessage('Tallennettu!');
         } catch (e) {
             this.props.errorStore!.addError(`Tallennus epäonnistui`, e);
         }
 
-        if (preventSetState) return;
+        if (this.props.isNewNode) return;
         this.setState({ isLoading: false });
         this.props.nodeStore!.setIsEditingDisabled(true);
     };

--- a/src/components/sidebar/nodeView/ShortIdInput.tsx
+++ b/src/components/sidebar/nodeView/ShortIdInput.tsx
@@ -116,7 +116,9 @@ class ShortIdInput extends React.Component<IStopFormProps, IStopFormState> {
 
     private renderValidationNotification = () => {
         const validationResult = this.props.nodeInvalidPropertiesMap['shortIdString'];
-        if (this.props.isEditingDisabled || validationResult.errorMessage) return null;
+        if (this.props.isEditingDisabled || (validationResult && validationResult.errorMessage)) {
+            return null;
+        }
         const selectedShortId = this.props.node.shortIdString;
         if (!selectedShortId) return null;
 

--- a/src/components/sidebar/nodeView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/StopAreaView.tsx
@@ -305,7 +305,7 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                                     'Pysäkkialueid'
                                 )}
                                 selected={stopArea.stopAreaGroupId}
-                                label='PYSÄKKIALUE'
+                                label='PYSÄKKIALUE RYHMÄ'
                             />
                             <Dropdown
                                 onChange={this.onChangeStopAreaProperty('terminalAreaId')}

--- a/src/components/sidebar/nodeView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/StopAreaView.tsx
@@ -125,7 +125,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
 
     private initNewStopArea = async () => {
         this.setState({ isLoading: true });
-        this.props.stopAreaStore!.clear();
 
         const stopArea = StopAreaFactory.createNewStopArea();
         this.props.stopAreaStore!.init({
@@ -201,6 +200,7 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
             .toTarget(':id', stopArea.id)
             .toLink();
         navigator.goTo(stopAreaViewStopArea);
+        console.log(stopAreaViewStopArea);
     };
 
     private validateStopArea = () => {

--- a/src/components/sidebar/nodeView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/StopAreaView.tsx
@@ -1,0 +1,277 @@
+import classnames from 'classnames';
+import { reaction, IReactionDisposer } from 'mobx';
+import { inject, observer } from 'mobx-react';
+import React from 'react';
+import { match } from 'react-router';
+import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
+import Loader from '~/components/shared/loader/Loader';
+import ButtonType from '~/enums/buttonType';
+import TransitType from '~/enums/transitType';
+import StopAreaFactory from '~/factories/stopAreaFactory';
+import { IStopArea } from '~/models';
+import stopAreaValidationModel from '~/models/validationModels/stopAreaValidationModel';
+import navigator from '~/routing/navigator';
+import routeBuilder from '~/routing/routeBuilder';
+import SubSites from '~/routing/subSites';
+import StopAreaService from '~/services/stopAreaService';
+import { AlertStore } from '~/stores/alertStore';
+import { CodeListStore } from '~/stores/codeListStore';
+import { ErrorStore } from '~/stores/errorStore';
+import { StopAreaStore } from '~/stores/stopAreaStore';
+import { Button, Dropdown, TransitToggleButtonBar } from '../../controls';
+import InputContainer from '../../controls/InputContainer';
+import TextContainer from '../../controls/TextContainer';
+import SidebarHeader from '../SidebarHeader';
+import * as s from './stopAreaView.scss';
+
+interface IStopAreaViewProps {
+    isNewStopArea: boolean;
+    match?: match<any>;
+    codeListStore?: CodeListStore;
+    errorStore?: ErrorStore;
+    stopAreaStore?: StopAreaStore;
+    alertStore?: AlertStore;
+}
+
+interface IStopAreaViewState {
+    isLoading: boolean;
+    invalidPropertiesMap: object;
+}
+
+@inject('stopAreaStore', 'errorStore', 'alertStore', 'codeListStore')
+@observer
+class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> {
+    private isEditingDisabledListener: IReactionDisposer;
+
+    constructor(props: IStopAreaViewProps) {
+        super(props);
+        this.state = {
+            isLoading: false,
+            invalidPropertiesMap: {}
+        };
+    }
+
+    async componentDidMount() {
+        if (this.props.isNewStopArea) {
+            await this.initNewStopArea();
+        } else {
+            await this.initExistingStopArea();
+        }
+
+        if (this.props.stopAreaStore!.stopArea) {
+            this.validateStopArea();
+        }
+        this.props.stopAreaStore!.setIsEditingDisabled(!this.props.isNewStopArea);
+        this.isEditingDisabledListener = reaction(
+            () => this.props.stopAreaStore!.isEditingDisabled,
+            this.onChangeIsEditingDisabled
+        );
+    }
+
+    componentDidUpdate(prevProps: IStopAreaViewProps) {
+        const params = this.props.match!.params.id;
+        if (prevProps.match!.params.id !== params) {
+            if (this.props.isNewStopArea) {
+                this.initNewStopArea();
+            } else {
+                this.initExistingStopArea();
+            }
+        }
+    }
+
+    componentWillUnmount() {
+        this.props.stopAreaStore!.clear();
+        this.isEditingDisabledListener();
+    }
+
+    private initExistingStopArea = async () => {
+        this.setState({ isLoading: true });
+
+        const stopAreaId = this.props.match!.params.id;
+        try {
+            if (stopAreaId) {
+                const stopArea = await StopAreaService.fetchStopArea(stopAreaId);
+                this.props.stopAreaStore!.init({
+                    stopArea,
+                    isNewStopArea: false
+                });
+            }
+        } catch (e) {
+            this.props.errorStore!.addError(
+                `Haku löytää pysäkkialue, jolla on pysalueid ${stopAreaId}, ei onnistunut.`,
+                e
+            );
+        }
+        this.setState({ isLoading: false });
+    };
+
+    private initNewStopArea = async () => {
+        this.setState({ isLoading: true });
+        this.props.stopAreaStore!.clear();
+
+        const stopArea = StopAreaFactory.createNewStopArea();
+        this.props.stopAreaStore!.init({
+            stopArea,
+            isNewStopArea: true
+        });
+
+        this.validateStopArea();
+
+        this.setState({ isLoading: false });
+    };
+
+    private save = async () => {
+        this.setState({ isLoading: true });
+        try {
+            if (this.props.isNewStopArea) {
+                await StopAreaService.createStopArea(this.props.stopAreaStore!.stopArea);
+            } else {
+                await StopAreaService.updateStopArea(this.props.stopAreaStore!.stopArea);
+                this.props.stopAreaStore!.setOldStopArea(this.props.stopAreaStore!.stopArea);
+            }
+            await this.props.alertStore!.setFadeMessage('Tallennettu!');
+        } catch (e) {
+            this.props.errorStore!.addError(`Tallennus epäonnistui`, e);
+        }
+
+        if (this.props.isNewStopArea) {
+            this.navigateToNewStopArea();
+            return;
+        }
+        this.setState({ isLoading: false });
+        this.props.stopAreaStore!.setIsEditingDisabled(true);
+    };
+
+    private onChangeIsEditingDisabled = () => {
+        this.clearInvalidPropertiesMap();
+        const stopAreaStore = this.props.stopAreaStore;
+        if (stopAreaStore!.isEditingDisabled) {
+            stopAreaStore!.resetChanges();
+        } else {
+            this.validateStopArea();
+        }
+    };
+
+    private navigateToNewStopArea = () => {
+        const stopArea = this.props.stopAreaStore!.stopArea;
+        const stopAreaViewStopArea = routeBuilder
+            .to(SubSites.stopArea)
+            .toTarget(':id', stopArea.id)
+            .toLink();
+        navigator.goTo(stopAreaViewStopArea);
+    };
+
+    private validateStopArea = () => {
+        this.validateAllProperties(stopAreaValidationModel, this.props.stopAreaStore!.stopArea);
+    };
+
+    private selectTransitType = (transitType: TransitType) => {
+        this.props.stopAreaStore!.updateStopAreaProperty('transitType', transitType);
+        this.validateProperty(stopAreaValidationModel['transitType'], 'transitType', transitType);
+    };
+
+    // TODO: onChangeProperty listener with:
+    // this.validateProperty(stopAreaValidationModel[property], property, value);
+
+    private onChangeStopAreaProperty = (property: keyof IStopArea) => (value: any) => {
+        this.props.stopAreaStore!.updateStopAreaProperty(property, value);
+    };
+
+    render() {
+        const stopArea = this.props.stopAreaStore!.stopArea;
+        const invalidPropertiesMap = this.state.invalidPropertiesMap;
+        if (this.state.isLoading) {
+            return (
+                <div className={classnames(s.stopAreaView, s.loaderContainer)}>
+                    <Loader />
+                </div>
+            );
+        }
+        if (!stopArea) return null;
+
+        const isEditingDisabled = this.props.stopAreaStore!.isEditingDisabled;
+        const transitType = this.props.stopAreaStore!.stopArea.transitType;
+
+        const isSaveButtonDisabled =
+            !transitType ||
+            isEditingDisabled ||
+            !this.props.stopAreaStore!.isDirty ||
+            !this.isFormValid();
+        const selectedTransitTypes = stopArea!.transitType ? [stopArea!.transitType!] : [];
+
+        return (
+            <div className={s.stopAreaView}>
+                <div className={s.content}>
+                    <SidebarHeader
+                        isEditButtonVisible={!this.props.isNewStopArea}
+                        isEditing={!isEditingDisabled}
+                        shouldShowClosePromptMessage={this.props.stopAreaStore!.isDirty!}
+                        onEditButtonClick={this.props.stopAreaStore!.toggleIsEditingDisabled}
+                    >
+                        Pysäkkialue
+                    </SidebarHeader>
+                    <div className={s.formSection}>
+                        <div className={s.flexRow}>
+                            <div className={s.formItem}>
+                                <div className={s.inputLabel}>VERKKO</div>
+                                <TransitToggleButtonBar
+                                    selectedTransitTypes={selectedTransitTypes}
+                                    toggleSelectedTransitType={this.selectTransitType}
+                                    disabled={!this.props.isNewStopArea}
+                                />
+                            </div>
+                        </div>
+                        <div className={s.flexRow}>
+                            <InputContainer
+                                label='NIMI'
+                                disabled={isEditingDisabled}
+                                value={stopArea.nameFi}
+                                validationResult={invalidPropertiesMap['nameFi']}
+                                onChange={this.onChangeStopAreaProperty('nameFi')}
+                            />
+                            <InputContainer
+                                label='NIMI RUOTSIKSI'
+                                disabled={isEditingDisabled}
+                                value={stopArea.nameSw}
+                                validationResult={invalidPropertiesMap['nameSw']}
+                                onChange={this.onChangeStopAreaProperty('nameSw')}
+                            />
+                        </div>
+
+                        <div className={s.flexRow}>
+                            <Dropdown
+                                onChange={this.onChangeStopAreaProperty('stopAreaGroupId')}
+                                disabled={isEditingDisabled}
+                                items={this.props.codeListStore!.getDropdownItemList(
+                                    'Pysäkkialueid'
+                                )}
+                                selected={stopArea.stopAreaGroupId}
+                                label='PYSÄKKIALUE'
+                            />
+                            {/* TODO: */}
+                            <div>TERMINAALI</div>
+                        </div>
+                        {!this.props.isNewStopArea && (
+                            <div className={s.flexRow}>
+                                <TextContainer label='MUOKANNUT' value={stopArea.modifiedBy} />
+                                <TextContainer
+                                    label='MUOKATTU PVM'
+                                    isTimeIncluded={true}
+                                    value={stopArea.modifiedOn}
+                                />
+                            </div>
+                        )}
+                    </div>
+                </div>
+                <Button
+                    type={ButtonType.SAVE}
+                    disabled={isSaveButtonDisabled}
+                    onClick={() => this.save()}
+                >
+                    Tallenna muutokset
+                </Button>
+            </div>
+        );
+    }
+}
+export default StopAreaView;

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -10,6 +10,9 @@ import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import ButtonType from '~/enums/buttonType';
 import { INode, IStop } from '~/models';
 import stopValidationModel from '~/models/validationModels/stopValidationModel';
+import navigator from '~/routing/navigator';
+import RouteBuilder from '~/routing/routeBuilder';
+import SubSites from '~/routing/subSites';
 import StopService, { IStopAreaItem, IStopSectionItem } from '~/services/stopService';
 import { CodeListStore } from '~/stores/codeListStore';
 import { NodeStore } from '~/stores/nodeStore';
@@ -175,6 +178,13 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
         const shortIdLetterItems = this.props.codeListStore!.getDropdownItemList('Lyhyttunnus');
         shortIdLetterItems.forEach(item => (item.label = `${item.value} - ${item.label}`));
         return shortIdLetterItems;
+    };
+
+    private redirectToNewStopArea = () => {
+        const url = RouteBuilder.to(SubSites.newStopArea)
+            .clear()
+            .toLink();
+        navigator.goTo(url);
     };
 
     render() {
@@ -353,8 +363,7 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
                             validationResult={invalidPropertiesMap['areaId']}
                         />
                         <Button
-                            // TODO: implement the button functionality
-                            onClick={() => window.alert('Toteutuksen suunnittelu kesken.')}
+                            onClick={() => this.redirectToNewStopArea()}
                             disabled={isEditingDisabled}
                             type={ButtonType.SQUARE}
                             className={s.createNewStopAreaButton}

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -13,7 +13,8 @@ import stopValidationModel from '~/models/validationModels/stopValidationModel';
 import navigator from '~/routing/navigator';
 import RouteBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
-import StopService, { IStopAreaItem, IStopSectionItem } from '~/services/stopService';
+import StopAreaService, { IStopAreaItem } from '~/services/stopAreaService';
+import StopService, { IStopSectionItem } from '~/services/stopService';
 import { CodeListStore } from '~/stores/codeListStore';
 import { NodeStore } from '~/stores/nodeStore';
 import SidebarHeader from '../SidebarHeader';
@@ -70,7 +71,7 @@ class StopForm extends ViewFormBase<IStopFormProps, IStopFormState> {
         if (this.props.isNewStop) {
             this.props.nodeStore!.fetchAddressData();
         }
-        const stopAreas: IStopAreaItem[] = await StopService.fetchAllStopAreas();
+        const stopAreas: IStopAreaItem[] = await StopAreaService.fetchAllStopAreas();
         const stopSections: IStopSectionItem[] = await StopService.fetchAllStopSections();
         if (this.mounted) {
             this.setState({

--- a/src/components/sidebar/nodeView/stopAreaView.scss
+++ b/src/components/sidebar/nodeView/stopAreaView.scss
@@ -1,0 +1,23 @@
+@import '../../shared/styles/common';
+@import '../../shared/styles/sidebar';
+@import '../../shared/styles/flexbox';
+@import '../../shared/styles/form';
+
+.stopAreaView {
+    width: $sidebarExtraWide;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    &.loaderContainer > div {
+        margin: 30px auto;
+    }
+
+    .content {
+        overflow-y: auto;
+        flex-grow: 1;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/src/components/sidebar/nodeView/stopAreaView.scss
+++ b/src/components/sidebar/nodeView/stopAreaView.scss
@@ -4,8 +4,7 @@
 @import '../../shared/styles/form';
 
 .stopAreaView {
-    width: $sidebarExtraWide;
-    height: 100%;
+    width: $sidebarWide;
     display: flex;
     flex-direction: column;
 
@@ -14,10 +13,8 @@
     }
 
     .content {
+        padding: 20px;
         overflow-y: auto;
         flex-grow: 1;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
     }
 }

--- a/src/enums/endpoints.ts
+++ b/src/enums/endpoints.ts
@@ -8,6 +8,7 @@ enum endpoints { // TODO: rename as endpointPath
     ROUTEPATH = 'routePath',
     ROUTELINK = 'routeLink',
     NODE = 'node',
+    STOP_AREA = 'stopArea',
     LINK = 'link'
 }
 

--- a/src/factories/stopAreaFactory.ts
+++ b/src/factories/stopAreaFactory.ts
@@ -8,6 +8,7 @@ class StopAreaFactory {
             transitType: externalStopArea.verkko,
             nameFi: externalStopArea.nimi,
             nameSw: externalStopArea.nimir,
+            terminalAreaId: externalStopArea.termid,
             modifiedBy: externalStopArea.tallentaja,
             modifiedOn: externalStopArea.tallpvm ? new Date(externalStopArea.tallpvm) : undefined,
             stopAreaGroupId: externalStopArea.pysakkialueryhma
@@ -20,6 +21,7 @@ class StopAreaFactory {
             transitType: undefined,
             nameFi: '',
             nameSw: '',
+            terminalAreaId: '',
             modifiedBy: '',
             modifiedOn: new Date(),
             stopAreaGroupId: undefined

--- a/src/factories/stopAreaFactory.ts
+++ b/src/factories/stopAreaFactory.ts
@@ -1,0 +1,30 @@
+import { IStopArea } from '~/models';
+import IExternalStopArea from '~/models/externals/IExternalStopArea';
+
+class StopAreaFactory {
+    public static mapExternalStopArea = (externalStopArea: IExternalStopArea): IStopArea => {
+        return {
+            id: externalStopArea.pysalueid,
+            transitType: externalStopArea.verkko,
+            nameFi: externalStopArea.nimi,
+            nameSw: externalStopArea.nimir,
+            modifiedBy: externalStopArea.tallentaja,
+            modifiedOn: externalStopArea.tallpvm ? new Date(externalStopArea.tallpvm) : undefined,
+            stopAreaGroupId: externalStopArea.pysakkialueryhma
+        };
+    };
+
+    public static createNewStopArea = (): IStopArea => {
+        return {
+            id: '',
+            transitType: undefined,
+            nameFi: '',
+            nameSw: '',
+            modifiedBy: '',
+            modifiedOn: new Date(),
+            stopAreaGroupId: undefined
+        };
+    };
+}
+
+export default StopAreaFactory;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import RoutePathStore from './stores/routePathStore';
 import RouteStore from './stores/routeStore';
 import SearchResultStore from './stores/searchResultStore';
 import SearchStore from './stores/searchStore';
+import StopAreaStore from './stores/stopAreaStore';
 import ToolbarStore from './stores/toolbarStore';
 import ApolloClient from './util/ApolloClient';
 
@@ -51,6 +52,7 @@ const stores = {
     toolbarStore: ToolbarStore,
     networkStore: NetworkStore,
     nodeStore: NodeStore,
+    stopAreaStore: StopAreaStore,
     linkStore: LinkStore,
     alertStore: AlertStore,
     codeListStore: CodeListStore,

--- a/src/models/IStopArea.ts
+++ b/src/models/IStopArea.ts
@@ -1,0 +1,11 @@
+import TransitType from '~/enums/transitType';
+
+export default interface IStopArea {
+    id: string;
+    transitType?: TransitType;
+    nameFi: string;
+    nameSw: string;
+    modifiedBy?: string;
+    modifiedOn?: Date;
+    stopAreaGroupId?: string;
+}

--- a/src/models/IStopArea.ts
+++ b/src/models/IStopArea.ts
@@ -5,6 +5,7 @@ export default interface IStopArea {
     transitType?: TransitType;
     nameFi: string;
     nameSw: string;
+    terminalAreaId: string;
     modifiedBy?: string;
     modifiedOn?: Date;
     stopAreaGroupId?: string;

--- a/src/models/externals/IExternalStopArea.ts
+++ b/src/models/externals/IExternalStopArea.ts
@@ -6,7 +6,7 @@ export default interface IExternalStopArea {
     nimi: string;
     nimir: string;
     termid: string;
-    tallpvm: Date;
-    tallentaja: string;
+    tallpvm?: Date;
+    tallentaja?: string;
     pysakkialueryhma: string;
 }

--- a/src/models/externals/IExternalStopArea.ts
+++ b/src/models/externals/IExternalStopArea.ts
@@ -1,0 +1,12 @@
+import TransitType from '~/enums/transitType';
+
+export default interface IExternalStopArea {
+    pysalueid: string;
+    verkko: TransitType;
+    nimi: string;
+    nimir: string;
+    termid: string;
+    tallpvm: Date;
+    tallentaja: string;
+    pysakkialueryhma: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -7,6 +7,7 @@ import IRoute from './IRoute';
 import IRoutePath from './IRoutePath';
 import IRoutePathLink from './IRoutePathLink';
 import IStop from './IStop';
+import IStopArea from './IStopArea';
 import IViaName from './IViaName';
 
 export {
@@ -14,6 +15,7 @@ export {
     ILineHeader,
     INode,
     IStop,
+    IStopArea,
     ILink,
     IRoute,
     IRoutePath,

--- a/src/models/validationModels/stopAreaValidationModel.ts
+++ b/src/models/validationModels/stopAreaValidationModel.ts
@@ -1,0 +1,18 @@
+import { IStopArea } from '..';
+
+const nameRule = 'required|min:1|max:20|string';
+
+type StopAreaKeys = keyof IStopArea;
+type IStopAreaValidationModel = { [key in StopAreaKeys]: string };
+
+const stopAreaValidationModel: IStopAreaValidationModel = {
+    id: '',
+    transitType: 'required|min:1',
+    nameFi: nameRule,
+    nameSw: nameRule,
+    modifiedBy: '',
+    modifiedOn: '',
+    stopAreaGroupId: 'required|min:1|max:2'
+};
+
+export default stopAreaValidationModel;

--- a/src/models/validationModels/stopAreaValidationModel.ts
+++ b/src/models/validationModels/stopAreaValidationModel.ts
@@ -7,12 +7,13 @@ type IStopAreaValidationModel = { [key in StopAreaKeys]: string };
 
 const stopAreaValidationModel: IStopAreaValidationModel = {
     id: '',
-    transitType: 'required|min:1',
+    transitType: 'required|min:1|max:1|string',
     nameFi: nameRule,
     nameSw: nameRule,
+    terminalAreaId: 'required|min:1|max:10|string',
     modifiedBy: '',
     modifiedOn: '',
-    stopAreaGroupId: 'required|min:1|max:2'
+    stopAreaGroupId: 'required|min:1|max:2|string'
 };
 
 export default stopAreaValidationModel;

--- a/src/routing/subSites.ts
+++ b/src/routing/subSites.ts
@@ -15,6 +15,8 @@ enum SubSites {
     newRoutePath = '/routePath/new',
     node = '/node/:id',
     newNode = '/node/new/:id',
+    stopArea = '/stopArea/:id',
+    newStopArea = '/stopArea/new',
     login = '/login',
     afterLogin = '/afterLogin'
 }

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -231,6 +231,19 @@ const getAllStopAreas = () => {
     `;
 };
 
+const getAllTerminalAreas = () => {
+    return gql`
+        query getAllTerminalAreas {
+            node: allTerminaalialues {
+                nodes {
+                    termid
+                    nimi
+                }
+            }
+        }
+    `;
+};
+
 const getAllStopSections = () => {
     return gql`
         query getAllStopSections {
@@ -600,6 +613,7 @@ export default {
     getAllRoutePathPrimaryKeysQuery,
     getStopAreaQuery,
     getAllStopAreas,
+    getAllTerminalAreas,
     getLineHeaderQuery,
     getAllLineHeadersQuery,
     getAllStopSections,

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -208,6 +208,14 @@ const getAllRoutePathPrimaryKeysQuery = () => {
     `;
 };
 
+const getStopAreaQuery = () => {
+    return gql`
+        query getStopArea {
+            // TODO
+        }
+    `;
+};
+
 const getAllStopAreas = () => {
     return gql`
         query getAllStopAreas {
@@ -577,6 +585,7 @@ export default {
     getAllCodeLists,
     getRoutePathsUsingLinkFromDate,
     getAllRoutePathPrimaryKeysQuery,
+    getStopAreaQuery,
     getAllStopAreas,
     getLineHeaderQuery,
     getAllLineHeadersQuery,

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -210,8 +210,10 @@ const getAllRoutePathPrimaryKeysQuery = () => {
 
 const getStopAreaQuery = () => {
     return gql`
-        query getStopArea {
-            // TODO
+        query getStopArea($stopAreaId: String!) {
+            stopArea: pysakkialueByPysalueid(pysalueid: $stopAreaId) {
+                ${stopAreaQueryFields}
+            }
         }
     `;
 };
@@ -387,6 +389,17 @@ const stopQueryFields = `
     nimiviimpvm
     vyohyke
     postinro
+`;
+
+const stopAreaQueryFields = `
+    pysalueid
+    verkko
+    nimi
+    nimir
+    termid
+    tallpvm
+    tallentaja
+    pysakkialueryhma
 `;
 
 const nodeQueryFields = `

--- a/src/services/stopAreaService.ts
+++ b/src/services/stopAreaService.ts
@@ -6,6 +6,16 @@ import ApiClient from '~/util/ApiClient';
 import ApolloClient from '~/util/ApolloClient';
 import GraphqlQueries from './graphqlQueries';
 
+interface ITerminalAreaItem {
+    id: string;
+    name: string;
+}
+
+interface IExternalTerminalArea {
+    termid: string;
+    nimi: string;
+}
+
 class StopAreaService {
     public static fetchStopArea = async (stopAreaId: string): Promise<IStopArea> => {
         // TODO: remove this hardcoded value
@@ -24,6 +34,25 @@ class StopAreaService {
     public static createStopArea = async (stopArea: IStopArea) => {
         await ApiClient.createObject(endpoints.STOP_AREA, stopArea);
     };
+
+    public static fetchAllTerminalAreas = async (): Promise<ITerminalAreaItem[]> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getAllTerminalAreas()
+        });
+
+        const terminalAreaItems: ITerminalAreaItem[] = queryResult.data.node.nodes.map(
+            (externalTerminalArea: IExternalTerminalArea) => {
+                return {
+                    id: externalTerminalArea.termid,
+                    name: externalTerminalArea.nimi
+                };
+            }
+        );
+
+        return terminalAreaItems;
+    };
 }
 
 export default StopAreaService;
+
+export { ITerminalAreaItem };

--- a/src/services/stopAreaService.ts
+++ b/src/services/stopAreaService.ts
@@ -11,6 +11,11 @@ interface ITerminalAreaItem {
     name: string;
 }
 
+interface IStopAreaItem {
+    pysalueid: string;
+    nimi: string;
+}
+
 interface IExternalTerminalArea {
     termid: string;
     nimi: string;
@@ -23,6 +28,14 @@ class StopAreaService {
             variables: { stopAreaId }
         });
         return StopAreaFactory.mapExternalStopArea(queryResult.data.stopArea);
+    };
+
+    public static fetchAllStopAreas = async (): Promise<IStopAreaItem[]> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getAllStopAreas()
+        });
+
+        return queryResult.data.node.nodes;
     };
 
     public static updateStopArea = async (stopArea: IStopArea) => {
@@ -53,4 +66,4 @@ class StopAreaService {
 
 export default StopAreaService;
 
-export { ITerminalAreaItem };
+export { IStopAreaItem, ITerminalAreaItem };

--- a/src/services/stopAreaService.ts
+++ b/src/services/stopAreaService.ts
@@ -1,0 +1,27 @@
+import { ApolloQueryResult } from 'apollo-client';
+import endpoints from '~/enums/endpoints';
+import StopAreaFactory from '~/factories/stopAreaFactory';
+import IStopArea from '~/models/IStopArea';
+import ApiClient from '~/util/ApiClient';
+import ApolloClient from '~/util/ApolloClient';
+import GraphqlQueries from './graphqlQueries';
+
+class StopAreaService {
+    public static fetchStopArea = async (stopAreaId: string): Promise<IStopArea> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getStopAreaQuery(),
+            variables: { stopAreaId }
+        });
+        return StopAreaFactory.mapExternalStopArea(queryResult.data.stopArea);
+    };
+
+    public static updateStopArea = async (stopArea: IStopArea) => {
+        await ApiClient.updateObject(endpoints.LINK, stopArea);
+    };
+
+    public static createStopArea = async (stopArea: IStopArea) => {
+        await ApiClient.createObject(endpoints.LINK, stopArea);
+    };
+}
+
+export default StopAreaService;

--- a/src/services/stopAreaService.ts
+++ b/src/services/stopAreaService.ts
@@ -8,19 +8,21 @@ import GraphqlQueries from './graphqlQueries';
 
 class StopAreaService {
     public static fetchStopArea = async (stopAreaId: string): Promise<IStopArea> => {
+        // TODO: remove this hardcoded value
+        const tempStopAreaId = '110001';
         const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
             query: GraphqlQueries.getStopAreaQuery(),
-            variables: { stopAreaId }
+            variables: { stopAreaId: tempStopAreaId }
         });
         return StopAreaFactory.mapExternalStopArea(queryResult.data.stopArea);
     };
 
     public static updateStopArea = async (stopArea: IStopArea) => {
-        await ApiClient.updateObject(endpoints.LINK, stopArea);
+        await ApiClient.updateObject(endpoints.STOP_AREA, stopArea);
     };
 
     public static createStopArea = async (stopArea: IStopArea) => {
-        await ApiClient.createObject(endpoints.LINK, stopArea);
+        await ApiClient.createObject(endpoints.STOP_AREA, stopArea);
     };
 }
 

--- a/src/services/stopAreaService.ts
+++ b/src/services/stopAreaService.ts
@@ -18,11 +18,9 @@ interface IExternalTerminalArea {
 
 class StopAreaService {
     public static fetchStopArea = async (stopAreaId: string): Promise<IStopArea> => {
-        // TODO: remove this hardcoded value
-        const tempStopAreaId = '110001';
         const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
             query: GraphqlQueries.getStopAreaQuery(),
-            variables: { stopAreaId: tempStopAreaId }
+            variables: { stopAreaId }
         });
         return StopAreaFactory.mapExternalStopArea(queryResult.data.stopArea);
     };

--- a/src/services/stopService.ts
+++ b/src/services/stopService.ts
@@ -4,11 +4,6 @@ import IExternalNode from '~/models/externals/IExternalNode';
 import ApolloClient from '~/util/ApolloClient';
 import GraphqlQueries from './graphqlQueries';
 
-interface IStopAreaItem {
-    pysalueid: string;
-    nimi: string;
-}
-
 interface IStopSectionItem {
     selite: string;
 }
@@ -21,15 +16,6 @@ interface IReservedShortIdItem {
 const SHORT_ID_LENGTH = 4;
 
 class StopService {
-    // TODO: move to stopAreaService
-    public static fetchAllStopAreas = async (): Promise<IStopAreaItem[]> => {
-        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
-            query: GraphqlQueries.getAllStopAreas()
-        });
-
-        return queryResult.data.node.nodes;
-    };
-
     public static fetchAllStopSections = async (): Promise<IStopSectionItem[]> => {
         const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
             query: GraphqlQueries.getAllStopSections()
@@ -102,4 +88,4 @@ const _generateAllShortIdVariations = (numberCount: number) => {
 
 export default StopService;
 
-export { IStopAreaItem, IStopSectionItem };
+export { IStopSectionItem };

--- a/src/services/stopService.ts
+++ b/src/services/stopService.ts
@@ -21,7 +21,7 @@ interface IReservedShortIdItem {
 const SHORT_ID_LENGTH = 4;
 
 class StopService {
-    // Expose function for testing
+    // TODO: move to stopAreaService
     public static fetchAllStopAreas = async (): Promise<IStopAreaItem[]> => {
         const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
             query: GraphqlQueries.getAllStopAreas()

--- a/src/stores/codeListStore.ts
+++ b/src/stores/codeListStore.ts
@@ -14,7 +14,8 @@ export type codeListName =
     | 'Lyhyttunnus'
     | 'Suunta'
     | 'Ajantasaus pysakki'
-    | 'Pysäkin käyttö';
+    | 'Pysäkin käyttö'
+    | 'Pysäkkialueid';
 
 export class CodeListStore {
     @observable private _codeListItems: ICodeListItem[];

--- a/src/stores/stopAreaStore.ts
+++ b/src/stores/stopAreaStore.ts
@@ -1,0 +1,104 @@
+import _ from 'lodash';
+import { action, computed, observable } from 'mobx';
+import TransitType from '~/enums/transitType';
+import { IStopArea } from '~/models';
+
+export interface UndoState {
+    stopArea: IStopArea;
+}
+
+export class StopAreaStore {
+    @observable private _stopArea: IStopArea | null;
+    @observable private _oldStopArea: IStopArea | null;
+    @observable private _isEditingDisabled: boolean;
+
+    constructor() {
+        this._stopArea = null;
+        this._oldStopArea = null;
+        this._isEditingDisabled = true;
+    }
+
+    @computed
+    get stopArea() {
+        return this._stopArea!;
+    }
+
+    @computed
+    get oldStopArea() {
+        return this._oldStopArea!;
+    }
+
+    @computed
+    get isDirty() {
+        return this._stopArea && !_.isEqual(this._stopArea, this._oldStopArea);
+    }
+
+    @computed
+    get isEditingDisabled() {
+        return this._isEditingDisabled;
+    }
+
+    @action
+    public init = ({
+        stopArea,
+        isNewStopArea
+    }: {
+        stopArea: IStopArea;
+        isNewStopArea: boolean;
+    }) => {
+        this.clear();
+
+        const oldStopArea = _.cloneDeep(stopArea);
+        const newStopArea = _.cloneDeep(stopArea);
+
+        this._stopArea = newStopArea;
+
+        this.setOldStopArea(oldStopArea);
+
+        this._isEditingDisabled = !isNewStopArea;
+    };
+
+    @action
+    public setOldStopArea = (stopArea: IStopArea) => {
+        this._oldStopArea = _.cloneDeep(stopArea);
+    };
+
+    @action
+    public updateStopAreaProperty = (
+        property: keyof IStopArea,
+        value: string | Date | TransitType
+    ) => {
+        this._stopArea = {
+            ...this._stopArea!,
+            [property]: value
+        };
+    };
+
+    @action
+    public setIsEditingDisabled = (isEditingDisabled: boolean) => {
+        this._isEditingDisabled = isEditingDisabled;
+    };
+
+    @action
+    public toggleIsEditingDisabled = () => {
+        this._isEditingDisabled = !this._isEditingDisabled;
+    };
+
+    @action
+    public clear = () => {
+        this._stopArea = null;
+        this._oldStopArea = null;
+        this._isEditingDisabled = true;
+    };
+
+    @action
+    public resetChanges = () => {
+        if (this._oldStopArea) {
+            this.init({ stopArea: this._oldStopArea, isNewStopArea: false });
+        }
+    };
+}
+
+const observableStopAreaStore = new StopAreaStore();
+
+export default observableStopAreaStore;


### PR DESCRIPTION
Closes #952 

Initial steps test:
* Insert to db: jr_lij_terminaalialue.sql
* Run prep_database.sql
* Run functions.sql

TODOs -> make a new card:

StopArea:
- termid shouldnt be required field
- stopArea's transitType should be editable always (also when editing existing stop area)
- fix stopArea validations
- when creating stop area, user should be redirected to it
- stopAreaGroup can only be edited if isNewStopArea = true
- show stops that belong to the stop area
    * on map, center map to the stops at initial page load
    * on sidebar, clicking each stop centers it on map
- CTRL + F TODO from diff, do something about those

StopForm:
- always show "luo uusi pysäkkialue" and edit button, when isEditingDisabled is true/false
- StopForm.tsx, add (i) button to open a specific pysäkkialue (remember to remove hardcoded pysäkkialue from StopAreaService)
- StopForm.tsx, changing stopArea should change stop.nameFi, stop.nameSw