### PR TITLE
Clearing queryValues by default

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -39,10 +39,7 @@ class NavigationBar extends Component<INavigationBarProps, INavigationBarState> 
     }
 
     private goToHomeView = () => {
-        const homeLink = routeBuilder
-            .to(SubSites.home)
-            .clear()
-            .toLink();
+        const homeLink = routeBuilder.to(SubSites.home).toLink();
         navigator.goTo(homeLink);
     };
 

--- a/src/components/map/layers/edit/RoutePathNeighborLinkLayer.tsx
+++ b/src/components/map/layers/edit/RoutePathNeighborLinkLayer.tsx
@@ -44,7 +44,6 @@ class RoutePathNeighborLinkLayer extends Component<IRoutePathLayerProps> {
                                     routePath.direction
                                 ].join(',')
                             )
-                            .clear()
                             .toLink();
                         return (
                             <div className={s.usageListItem} key={index}>

--- a/src/components/map/tools/AddNetworkNodeTool.ts
+++ b/src/components/map/tools/AddNetworkNodeTool.ts
@@ -30,7 +30,6 @@ class AddNetworkNodeTool implements BaseTool {
         ToolbarStore.selectTool(null);
         const coordinate = roundLatLng(clickEvent.detail.latlng);
         const url = RouteBuilder.to(SubSites.newNode)
-            .clear()
             .toTarget(':id', `${coordinate.lat}:${coordinate.lng}`)
             .toLink();
         navigator.goTo(url);

--- a/src/components/map/tools/SplitLinkTool.ts
+++ b/src/components/map/tools/SplitLinkTool.ts
@@ -33,7 +33,6 @@ class SplitLinkTool implements BaseTool {
         const link = LinkStore.link;
         if (!link) throw 'Valittua linkkiä ei löytynyt.';
         const url = RouteBuilder.to(SubSites.splitLink)
-            .clear()
             .toTarget(
                 ':id',
                 [link.startNode.id, link.endNode.id, link.transitType, nodeId].join(',')

--- a/src/components/shared/searchView/LineItem.tsx
+++ b/src/components/shared/searchView/LineItem.tsx
@@ -56,7 +56,7 @@ class LineItem extends React.Component<ILineItemProps, ILineItemState> {
     };
 
     private openRoute = (routeId: string) => () => {
-        const openRouteLink = RouteBuilder.to(SubSites.routes)
+        const openRouteLink = RouteBuilder.to(SubSites.routes, navigator.getQueryParamValues())
             .append(QueryParams.routes, routeId)
             .toLink();
         searchStore.setSearchInput('');

--- a/src/components/sidebar/PageNotFoundView.tsx
+++ b/src/components/sidebar/PageNotFoundView.tsx
@@ -6,10 +6,7 @@ import * as s from './pageNotFoundView.scss';
 
 class PageNotFoundView extends Component {
     private goToHomeView = () => {
-        const homeLink = routeBuilder
-            .to(SubSites.home)
-            .clear()
-            .toLink();
+        const homeLink = routeBuilder.to(SubSites.home).toLink();
         navigator.goTo(homeLink);
     };
 

--- a/src/components/sidebar/SidebarHeader.tsx
+++ b/src/components/sidebar/SidebarHeader.tsx
@@ -50,10 +50,7 @@ class SidebarHeader extends React.Component<ISidebarHeaderProps> {
     };
 
     private onCloseButtonClick = () => {
-        const homeLink = routeBuilder
-            .to(SubSites.home)
-            .clear()
-            .toLink();
+        const homeLink = routeBuilder.to(SubSites.home).toLink();
         this.optionalConfirmPrompt({
             message: closePromptMessage,
             defaultOnClick: () => navigator.goTo(homeLink),

--- a/src/components/sidebar/homeView/HomeView.tsx
+++ b/src/components/sidebar/homeView/HomeView.tsx
@@ -31,9 +31,7 @@ class HomeView extends React.Component<IHomeViewProps> {
     }
 
     private redirectToNewLineView = () => {
-        const url = RouteBuilder.to(SubSites.newLine)
-            .clear()
-            .toLink();
+        const url = RouteBuilder.to(SubSites.newLine).toLink();
         navigator.goTo(url);
     };
 

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -75,7 +75,6 @@ class StopForm extends Component<IStopFormProps> {
         let url;
         if (this.props.isNewStop) {
             url = RouteBuilder.to(SubSites.newStopArea)
-                .clear()
                 .append(
                     QueryParams.latLng,
                     `${node.coordinatesProjection.lat}:${node.coordinatesProjection.lng}`
@@ -83,7 +82,6 @@ class StopForm extends Component<IStopFormProps> {
                 .toLink();
         } else {
             url = RouteBuilder.to(SubSites.newStopArea)
-                .clear()
                 .append(QueryParams.nodeId, node.id)
                 .toLink();
         }

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -190,7 +190,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                 if (latLng) {
                     const url = routeBuilder
                         .to(SubSites.newNode)
-                        .clear()
                         .toTarget(':id', latLng)
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
@@ -199,7 +198,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                     const url = routeBuilder
                         .to(SubSites.node)
                         .toTarget(':id', nodeId)
-                        .clear()
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
                     navigator.goTo(url);

--- a/src/components/sidebar/routeListView/RouteItem.tsx
+++ b/src/components/sidebar/routeListView/RouteItem.tsx
@@ -45,7 +45,7 @@ class RouteItem extends React.Component<IRouteItemProps> {
     private closeRoute = () => {
         this.props.routeListStore!.removeFromRoutes(this.props.route.id);
         const closeRouteLink = routeBuilder
-            .to(subSites.current)
+            .to(subSites.current, navigator.getQueryParamValues())
             .remove(QueryParams.routes, this.props.route.id)
             .toLink();
         navigator.goTo(closeRouteLink);

--- a/src/components/sidebar/routeListView/RouteItem.tsx
+++ b/src/components/sidebar/routeListView/RouteItem.tsx
@@ -76,7 +76,6 @@ class RouteItem extends React.Component<IRouteItemProps> {
         const routeViewLink = routeBuilder
             .to(subSites.route)
             .toTarget(':id', this.props.route.id)
-            .clear()
             .toLink();
         navigator.goTo(routeViewLink);
     };

--- a/src/routing/routeBuilder.ts
+++ b/src/routing/routeBuilder.ts
@@ -5,7 +5,7 @@ import subSites from './subSites';
 export class RouteBuilder {
     /**
      * @param {string} subSites
-     * @param {Object} queryValues - { field: value, ... }
+     * @param {Object} queryValues - { field: value, ... } (use navigator.getQueryParamValues() for example)
      */
     public to = (subSites: subSites, queryValues?: any) => {
         return new RouteBuilderContext(Navigator.getPathName(), subSites, queryValues);

--- a/src/routing/routeBuilder.ts
+++ b/src/routing/routeBuilder.ts
@@ -8,11 +8,7 @@ export class RouteBuilder {
      * @param {Object} queryValues - { field: value, ... }
      */
     public to = (subSites: subSites, queryValues?: any) => {
-        return new RouteBuilderContext(
-            Navigator.getPathName(),
-            subSites,
-            queryValues ? queryValues : Navigator.getQueryParamValues()
-        );
+        return new RouteBuilderContext(Navigator.getPathName(), subSites, queryValues);
     };
 }
 

--- a/src/routing/routeBuilderContext.ts
+++ b/src/routing/routeBuilderContext.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import qs from 'qs';
 import QueryParams from './queryParams';
 import SubSites from './subSites';
@@ -10,7 +11,8 @@ class RouteBuilderContext {
     constructor(currentLink: string, linkToBuild: SubSites, queryValues: any) {
         this.currentLink = currentLink;
         this.linkToBuild = linkToBuild;
-        if (this.queryValues) {
+
+        if (!_.isEmpty(queryValues)) {
             this.queryValues = this.jsonCopy(queryValues);
         } else {
             this.queryValues = {};

--- a/src/routing/routeBuilderContext.ts
+++ b/src/routing/routeBuilderContext.ts
@@ -10,7 +10,11 @@ class RouteBuilderContext {
     constructor(currentLink: string, linkToBuild: SubSites, queryValues: any) {
         this.currentLink = currentLink;
         this.linkToBuild = linkToBuild;
-        this.queryValues = this.jsonCopy(queryValues);
+        if (this.queryValues) {
+            this.queryValues = this.jsonCopy(queryValues);
+        } else {
+            this.queryValues = {};
+        }
     }
 
     private jsonCopy = (jsonObject: JSON) => {
@@ -61,11 +65,6 @@ class RouteBuilderContext {
 
     public set = (param: QueryParams, value: string) => {
         this.queryValues[param] = value;
-        return this;
-    };
-
-    public clear = () => {
-        this.queryValues = {};
         return this;
     };
 }


### PR DESCRIPTION
Closes #1174 

Test that the app still works like it should.

* Now if you go from routes/ page to a routePath, the query value ?routes[0]=0033 is cleared out (looks better)
* If you create a new stop, go to new stopArea form and then open a link from map, query values are cleaned out.