### PR TITLE
1103 fix line view bugs

### DIFF
--- a/src/components/shared/tabs.scss
+++ b/src/components/shared/tabs.scss
@@ -1,9 +1,9 @@
 @import './styles/common';
 
 .tabs {
-    height: 100%;
     display: flex;
     flex-direction: column;
+    overflow-y: auto;
 
     .tabList {
         display: flex;
@@ -48,6 +48,7 @@
         height: 100%;
         display: flex;
         flex-direction: column;
+        overflow-y: auto;
 
         .contentItem {
             height: 100%;

--- a/src/components/sidebar/lineView/LineHeaderTable.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTable.tsx
@@ -73,10 +73,15 @@ class LineHeaderTable extends React.Component<ILineHeaderListProps, ILineHeaderS
     }
 
     private createNewLineHeader = () => {
-        const lastLineHeader = _.last(this.props.lineHeaderMassEditStore!.massEditLineHeaders)!
-            .lineHeader;
-        const defaultDate = new Date(lastLineHeader.endDate);
-        defaultDate.setDate(defaultDate.getDate() + 1);
+        const lastLineHeader = this.props.lineHeaderMassEditStore!.getLastLineHeader();
+        let defaultDate: Date;
+
+        if (lastLineHeader) {
+            defaultDate = new Date(lastLineHeader.endDate);
+            defaultDate.setDate(defaultDate.getDate() + 1);
+        } else {
+            defaultDate = new Date();
+        }
         const newLineHeader = LineHeaderFactory.createNewLineHeader({
             lineId: this.props.lineId,
             startDate: defaultDate,

--- a/src/components/sidebar/lineView/LineHeaderTable.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTable.tsx
@@ -74,13 +74,11 @@ class LineHeaderTable extends React.Component<ILineHeaderListProps, ILineHeaderS
 
     private createNewLineHeader = () => {
         const lastLineHeader = this.props.lineHeaderMassEditStore!.getLastLineHeader();
-        let defaultDate: Date;
+        let defaultDate: Date = new Date();
 
         if (lastLineHeader) {
             defaultDate = new Date(lastLineHeader.endDate);
             defaultDate.setDate(defaultDate.getDate() + 1);
-        } else {
-            defaultDate = new Date();
         }
         const newLineHeader = LineHeaderFactory.createNewLineHeader({
             lineId: this.props.lineId,

--- a/src/components/sidebar/lineView/LineHeaderTableRows.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTableRows.tsx
@@ -151,13 +151,17 @@ class LineHeaderTableRows extends React.Component<ILineHeaderListProps> {
                             <Button
                                 className={classnames(
                                     s.lineHeaderButton,
-                                    isEditingDisabled ? s.disabledLineHeaderButton : undefined
+                                    isEditingDisabled ? s.disabledLineHeaderButton : undefined,
+                                    isEditingDisabled && isSelectedLineHeader
+                                        ? s.highlightedBackground
+                                        : undefined
                                 )}
                                 hasReverseColor={true}
                                 onClick={this.createNewLineHeaderWithCopy(
                                     currentMassEditLineHeader.id
                                 )}
                                 disabled={isEditingDisabled}
+                                hasNoTransition={true}
                             >
                                 <FiCopy />
                             </Button>

--- a/src/components/sidebar/lineView/LineHeaderTableRows.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTableRows.tsx
@@ -51,9 +51,8 @@ class LineHeaderTableRows extends React.Component<ILineHeaderListProps> {
         const newLineHeader = _.cloneDeep(selectedLineHeader);
         newLineHeader.originalStartDate = undefined;
 
-        const lastLineHeader = _.last(this.props.lineHeaderMassEditStore!.massEditLineHeaders)!
-            .lineHeader;
-        const defaultDate = new Date(lastLineHeader.endDate);
+        const lastLineHeader = lineHeaderMassEditStore!.getLastLineHeader();
+        const defaultDate = new Date(lastLineHeader!.endDate);
         defaultDate.setDate(defaultDate.getDate() + 1);
         newLineHeader.startDate = toMidnightDate(defaultDate);
         newLineHeader.endDate = toMidnightDate(defaultDate);

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -178,52 +178,48 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
 
         return (
             <div className={s.lineView}>
-                <div className={s.content}>
-                    <div className={s.sidebarHeaderSection}>
-                        <SidebarHeader
-                            isEditButtonVisible={!this.props.isNewLine}
-                            onEditButtonClick={lineStore!.toggleIsEditingDisabled}
-                            isEditing={!lineStore!.isEditingDisabled}
-                            shouldShowClosePromptMessage={
-                                lineStore!.isDirty || lineHeaderMassEditStore!.isDirty
-                            }
-                            shouldShowEditButtonClosePromptMessage={lineStore!.isDirty}
-                        >
-                            {this.props.isNewLine
-                                ? 'Luo uusi linja'
-                                : `Linja ${lineStore!.line!.id}`}
-                        </SidebarHeader>
-                    </div>
-                    <Tabs>
-                        <TabList
-                            selectedTabIndex={this.state.selectedTabIndex}
-                            setSelectedTabIndex={this.setSelectedTabIndex}
-                        >
-                            <Tab>
-                                <div>Linjan tiedot</div>
-                            </Tab>
-                            <Tab isDisabled={this.props.isNewLine}>
-                                <div>Reitit</div>
-                            </Tab>
-                        </TabList>
-                        <ContentList selectedTabIndex={this.state.selectedTabIndex}>
-                            <ContentItem>
-                                <LineInfoTab
-                                    isEditingDisabled={isEditingDisabled}
-                                    isNewLine={this.props.isNewLine}
-                                    onChangeLineProperty={this.onChangeLineProperty}
-                                    invalidPropertiesMap={this.state.invalidPropertiesMap}
-                                    setValidatorResult={this.setValidatorResult}
-                                    saveLine={this.saveLine}
-                                    isLineSaveButtonDisabled={isSaveButtonDisabled}
-                                />
-                            </ContentItem>
-                            <ContentItem>
-                                <LineRoutesTab />
-                            </ContentItem>
-                        </ContentList>
-                    </Tabs>
+                <div className={s.sidebarHeaderSection}>
+                    <SidebarHeader
+                        isEditButtonVisible={!this.props.isNewLine}
+                        onEditButtonClick={lineStore!.toggleIsEditingDisabled}
+                        isEditing={!lineStore!.isEditingDisabled}
+                        shouldShowClosePromptMessage={
+                            lineStore!.isDirty || lineHeaderMassEditStore!.isDirty
+                        }
+                        shouldShowEditButtonClosePromptMessage={lineStore!.isDirty}
+                    >
+                        {this.props.isNewLine ? 'Luo uusi linja' : `Linja ${lineStore!.line!.id}`}
+                    </SidebarHeader>
                 </div>
+                <Tabs>
+                    <TabList
+                        selectedTabIndex={this.state.selectedTabIndex}
+                        setSelectedTabIndex={this.setSelectedTabIndex}
+                    >
+                        <Tab>
+                            <div>Linjan tiedot</div>
+                        </Tab>
+                        <Tab isDisabled={this.props.isNewLine}>
+                            <div>Reitit</div>
+                        </Tab>
+                    </TabList>
+                    <ContentList selectedTabIndex={this.state.selectedTabIndex}>
+                        <ContentItem>
+                            <LineInfoTab
+                                isEditingDisabled={isEditingDisabled}
+                                isNewLine={this.props.isNewLine}
+                                onChangeLineProperty={this.onChangeLineProperty}
+                                invalidPropertiesMap={this.state.invalidPropertiesMap}
+                                setValidatorResult={this.setValidatorResult}
+                                saveLine={this.saveLine}
+                                isLineSaveButtonDisabled={isSaveButtonDisabled}
+                            />
+                        </ContentItem>
+                        <ContentItem>
+                            <LineRoutesTab />
+                        </ContentItem>
+                    </ContentList>
+                </Tabs>
             </div>
         );
     }

--- a/src/components/sidebar/lineView/lineInfoTab.scss
+++ b/src/components/sidebar/lineView/lineInfoTab.scss
@@ -5,7 +5,5 @@
 .lineInfoTabView {
     display: flex;
     flex-direction: column;
-    overflow-y: auto;
-    height: 100%;
     padding: 15px;
 }

--- a/src/components/sidebar/lineView/lineView.scss
+++ b/src/components/sidebar/lineView/lineView.scss
@@ -12,12 +12,4 @@
     &.loaderContainer > div {
         margin: 30px auto;
     }
-
-    .content {
-        overflow-y: auto;
-        flex-grow: 1;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-    }
 }

--- a/src/stores/lineHeaderMassEditStore.ts
+++ b/src/stores/lineHeaderMassEditStore.ts
@@ -219,6 +219,14 @@ export class LineHeaderMassEditStore {
     };
 
     @action
+    public getLastLineHeader = (): ILineHeader | null => {
+        if (this._massEditLineHeaders && this._massEditLineHeaders.length > 0) {
+            return _.last(this._massEditLineHeaders!)!.lineHeader;
+        }
+        return null;
+    };
+
+    @action
     private sortLineHeadersById = () => {
         this._massEditLineHeaders = this._massEditLineHeaders!.slice().sort((a, b) =>
             a.id < b.id ? -1 : 1


### PR DESCRIPTION
Closes #1103 

Fixed issues:

* copy lineHeader button when disabled has wrong background
* create new line -> try to create lineHeader (throws error)
* double scrollbar bug in lineView with firefox.


Made a card for this: https://github.com/HSLdevcom/jore-map-ui/issues/1183
* switch back from stopAreaView with invalid properties -> save is possible when some fields are invalid (save button is green even though there are red validation messages)

* toggling edit lineHeaders button shouldn't close currently opened lineHeader
^ changed my mind. I think lineHeader form should be hidden when isEditing is false.