### PR TITLE
1183 node view stop using view form base

### DIFF
--- a/src/components/sidebar/lineView/LineInfoTab.tsx
+++ b/src/components/sidebar/lineView/LineInfoTab.tsx
@@ -24,7 +24,6 @@ interface ILineInfoTabProps {
     isEditingDisabled: boolean;
     isNewLine: boolean;
     isLineSaveButtonDisabled: boolean;
-    invalidPropertiesMap: object;
     saveLine: () => void;
 }
 
@@ -89,7 +88,7 @@ class LineInfoTab extends React.Component<ILineInfoTabProps, ILineInfoTabState> 
         const isEditingDisabled = this.props.isEditingDisabled;
         const isUpdating = !this.props.isNewLine || this.props.isEditingDisabled;
         const onChange = this.onChangeLineProperty;
-        const invalidPropertiesMap = this.props.invalidPropertiesMap;
+        const invalidPropertiesMap = this.props.lineStore!.invalidPropertiesMap;
         const selectedTransitTypes = line!.transitType ? [line!.transitType!] : [];
 
         return (
@@ -103,7 +102,7 @@ class LineInfoTab extends React.Component<ILineInfoTabProps, ILineInfoTabState> 
                                 toggleSelectedTransitType={this.selectTransitType}
                                 disabled={!this.props.isNewLine}
                                 errorMessage={
-                                    !invalidPropertiesMap['transitType'].isValid
+                                    !invalidPropertiesMap['transitType']?.isValid
                                         ? 'Verkon tyyppi täytyy valita.'
                                         : undefined
                                 }

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -145,7 +145,6 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
         const isEditingDisabled = lineStore!.isEditingDisabled;
         const isSaveButtonDisabled =
             isEditingDisabled || !lineStore!.isDirty || !lineStore!.isLineFormValid;
-        const invalidPropertiesMap = lineStore!.invalidPropertiesMap;
         return (
             <div className={s.lineView}>
                 <div className={s.sidebarHeaderSection}>
@@ -178,7 +177,6 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
                             <LineInfoTab
                                 isEditingDisabled={isEditingDisabled}
                                 isNewLine={this.props.isNewLine}
-                                invalidPropertiesMap={invalidPropertiesMap}
                                 saveLine={this.saveLine}
                                 isLineSaveButtonDisabled={isSaveButtonDisabled}
                             />

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -1,14 +1,10 @@
 import classnames from 'classnames';
-import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { match } from 'react-router';
 import { ContentItem, ContentList, Tab, Tabs, TabList } from '~/components/shared/Tabs';
-import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
 import LineFactory from '~/factories/lineFactory';
-import { ILine } from '~/models';
-import lineValidationModel from '~/models/validationModels/lineValidationModel';
 import navigator from '~/routing/navigator';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
@@ -35,36 +31,27 @@ interface ILineViewProps {
 
 interface ILineViewState {
     isLoading: boolean;
-    invalidPropertiesMap: object;
     selectedTabIndex: number;
 }
 
 @inject('lineStore', 'lineHeaderMassEditStore', 'errorStore', 'alertStore', 'mapStore')
 @observer
-class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
-    private isEditingDisabledListener: IReactionDisposer;
-
+class LineView extends React.Component<ILineViewProps, ILineViewState> {
     constructor(props: ILineViewProps) {
         super(props);
         this.state = {
             isLoading: true,
-            invalidPropertiesMap: {},
             selectedTabIndex: 0
         };
     }
 
     componentDidMount() {
         this.initialize();
-        this.isEditingDisabledListener = reaction(
-            () => this.props.lineStore!.isEditingDisabled,
-            this.onChangeIsEditingDisabled
-        );
         this.props.lineStore!.setIsEditingDisabled(!this.props.isNewLine);
     }
 
     componentWillUnmount() {
         this.props.lineStore!.clear();
-        this.isEditingDisabledListener();
     }
 
     private setSelectedTabIndex = (index: number) => {
@@ -81,7 +68,6 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
             await this.initExistingLine();
         }
         if (this.props.lineStore!.line) {
-            this.validateLine();
             this.setState({
                 isLoading: false
             });
@@ -92,7 +78,7 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
         try {
             if (!this.props.lineStore!.line) {
                 const newLine = LineFactory.createNewLine();
-                this.props.lineStore!.setLine(newLine);
+                this.props.lineStore!.init(newLine);
             }
         } catch (e) {
             this.props.errorStore!.addError('Uuden linjan luonti epäonnistui', e);
@@ -103,15 +89,10 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
         const lineId = this.props.match!.params.id;
         try {
             const line = await LineService.fetchLine(lineId);
-            this.props.lineStore!.setLine(line);
+            this.props.lineStore!.init(line);
         } catch (e) {
             this.props.errorStore!.addError('Linjan haku epäonnistui.', e);
         }
-    };
-
-    private onChangeLineProperty = (property: keyof ILine) => (value: any) => {
-        this.props.lineStore!.updateLineProperty(property, value);
-        this.validateProperty(lineValidationModel[property], property, value);
     };
 
     private saveLine = async () => {
@@ -136,19 +117,9 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
         }
         this.props.lineStore!.setOldLine(line!);
         this.setState({
-            invalidPropertiesMap: {},
             isLoading: false
         });
         this.props.lineStore!.setIsEditingDisabled(true);
-    };
-
-    private onChangeIsEditingDisabled = () => {
-        this.clearInvalidPropertiesMap();
-        if (this.props.lineStore!.isEditingDisabled) {
-            this.props.lineStore!.resetChanges();
-        } else {
-            this.validateLine();
-        }
     };
 
     private navigateToNewLine = () => {
@@ -158,10 +129,6 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
             .toTarget(':id', line!.id)
             .toLink();
         navigator.goTo(lineViewLink);
-    };
-
-    private validateLine = () => {
-        this.validateAllProperties(lineValidationModel, this.props.lineStore!.line);
     };
 
     render() {
@@ -177,8 +144,8 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
         if (!lineStore!.line) return null;
         const isEditingDisabled = lineStore!.isEditingDisabled;
         const isSaveButtonDisabled =
-            isEditingDisabled || !lineStore!.isDirty || !this.isFormValid();
-
+            isEditingDisabled || !lineStore!.isDirty || !lineStore!.isLineFormValid;
+        const invalidPropertiesMap = lineStore!.invalidPropertiesMap;
         return (
             <div className={s.lineView}>
                 <div className={s.sidebarHeaderSection}>
@@ -211,9 +178,7 @@ class LineView extends ViewFormBase<ILineViewProps, ILineViewState> {
                             <LineInfoTab
                                 isEditingDisabled={isEditingDisabled}
                                 isNewLine={this.props.isNewLine}
-                                onChangeLineProperty={this.onChangeLineProperty}
-                                invalidPropertiesMap={this.state.invalidPropertiesMap}
-                                setValidatorResult={this.setValidatorResult}
+                                invalidPropertiesMap={invalidPropertiesMap}
                                 saveLine={this.saveLine}
                                 isLineSaveButtonDisabled={isSaveButtonDisabled}
                             />

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -180,7 +180,7 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
         const stopAreaIdQueryParam = navigator.getQueryParam(QueryParams.stopAreaId);
         const stopAreaId = stopAreaIdQueryParam ? stopAreaIdQueryParam[0] : undefined;
         if (stopAreaId) {
-            this.props.nodeStore!.updateStop('stopAreaId', stopAreaId);
+            this.props.nodeStore!.updateStopProperty('stopAreaId', stopAreaId);
         }
     };
 
@@ -347,7 +347,6 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
                     />
                     {node.type === NodeType.STOP && node.stop && (
                         <StopView
-                            isEditingDisabled={isEditingDisabled}
                             node={node}
                             onNodePropertyChange={this.onChangeNodeProperty}
                             isNewStop={this.props.isNewNode}

--- a/src/components/sidebar/nodeView/StopView.tsx
+++ b/src/components/sidebar/nodeView/StopView.tsx
@@ -2,10 +2,8 @@ import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { IDropdownItem } from '~/components/controls/Dropdown';
-import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
 import { INode, IStop } from '~/models';
-import stopValidationModel from '~/models/validationModels/stopValidationModel';
 import StopAreaService, { IStopAreaItem } from '~/services/stopAreaService';
 import StopService, { IStopSectionItem } from '~/services/stopService';
 import { CodeListStore } from '~/stores/codeListStore';
@@ -16,7 +14,6 @@ import * as s from './stopView.scss';
 interface IStopViewProps {
     node: INode;
     isNewStop: boolean;
-    isEditingDisabled: boolean;
     nodeStore?: NodeStore;
     codeListStore?: CodeListStore;
     nodeInvalidPropertiesMap: object;
@@ -25,43 +22,29 @@ interface IStopViewProps {
 
 interface IStopViewState {
     isLoading: boolean;
-    invalidPropertiesMap: object;
-    isEditingDisabled: boolean;
     stopSections: IDropdownItem[];
 }
 
 @inject('nodeStore', 'codeListStore')
 @observer
-class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
-    private isEditingDisabledListener: IReactionDisposer;
+class StopView extends React.Component<IStopViewProps, IStopViewState> {
     private nodeListener: IReactionDisposer;
-    private stopPropertyListeners: IReactionDisposer[];
     private mounted: boolean;
 
     constructor(props: IStopViewProps) {
         super(props);
         this.state = {
             isLoading: true,
-            invalidPropertiesMap: {},
-            isEditingDisabled: false,
             stopSections: []
         };
-        this.stopPropertyListeners = [];
     }
 
     async componentDidMount() {
         this.mounted = true;
-        this.validateStop();
-        this.isEditingDisabledListener = reaction(
-            () => this.props.nodeStore!.isEditingDisabled,
-            this.onChangeIsEditingDisabled
-        );
         this.nodeListener = reaction(() => this.props.nodeStore!.node, this.onNodeChange);
-        this.createStopPropertyListeners();
         if (this.props.isNewStop) {
             this.props.nodeStore!.fetchAddressData();
         }
-        // TODO: rename as stopAreaItems
         const stopAreas: IStopAreaItem[] = await StopAreaService.fetchAllStopAreas();
         const stopSections: IStopSectionItem[] = await StopService.fetchAllStopSections();
 
@@ -76,45 +59,10 @@ class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
 
     componentWillUnmount() {
         this.mounted = false;
-        this.isEditingDisabledListener();
-        this.removeStopPropertyListeners();
         this.nodeListener();
     }
 
-    private createStopPropertyListeners = () => {
-        const nodeStore = this.props.nodeStore;
-        if (!nodeStore!.node) return;
-
-        const stop = nodeStore!.node.stop;
-        for (const property in stop!) {
-            if (Object.prototype.hasOwnProperty.call(stop, property)) {
-                const listener = this.createListener(property);
-                this.stopPropertyListeners.push(listener);
-            }
-        }
-    };
-
-    private createListener = (property: string) => {
-        return reaction(
-            () => this.props.nodeStore!.node && this.props.nodeStore!.node!.stop![property],
-            this.validateStopProperty(property)
-        );
-    };
-
-    private removeStopPropertyListeners = () => {
-        this.stopPropertyListeners.forEach((listener: IReactionDisposer) => listener());
-        this.stopPropertyListeners = [];
-    };
-
-    private onChangeIsEditingDisabled = () => {
-        this.clearInvalidPropertiesMap();
-        if (!this.props.nodeStore!.isEditingDisabled) this.validateStop();
-    };
-
     private onNodeChange = async () => {
-        this.validateStop();
-        this.removeStopPropertyListeners();
-        this.createStopPropertyListeners();
         if (
             !this.props.nodeStore!.node ||
             (!this.props.isNewStop && this.props.nodeStore!.isEditingDisabled)
@@ -122,15 +70,6 @@ class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
             return;
         }
         await this.props.nodeStore!.fetchAddressData();
-    };
-
-    private validateStopProperty = (property: string) => () => {
-        const nodeStore = this.props.nodeStore;
-        if (!nodeStore!.node) return;
-        const value = nodeStore!.node!.stop![property];
-        this.validateProperty(stopValidationModel[property], property, value);
-        const isStopFormValid = this.isFormValid();
-        nodeStore!.setIsStopFormValid(isStopFormValid);
     };
 
     private createStopSectionDropdownItems = (
@@ -145,17 +84,8 @@ class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
         });
     };
 
-    private validateStop = () => {
-        const node = this.props.nodeStore!.node;
-        if (!node) return;
-        const stop = node.stop;
-        this.validateAllProperties(stopValidationModel, stop);
-        const isStopFormValid = this.isFormValid();
-        this.props.nodeStore!.setIsStopFormValid(isStopFormValid);
-    };
-
     private updateStopProperty = (property: keyof IStop) => (value: any) => {
-        this.props.nodeStore!.updateStop(property, value);
+        this.props.nodeStore!.updateStopProperty(property, value);
     };
 
     private setCurrentStateIntoNodeCache = () => {
@@ -166,6 +96,7 @@ class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
 
     render() {
         const isEditingDisabled = this.props.nodeStore!.isEditingDisabled;
+        const invalidPropertiesMap = this.props.nodeStore!.stopInvalidPropertiesMap;
         const { node, isNewStop, onNodePropertyChange } = this.props;
 
         if (this.state.isLoading) {
@@ -183,7 +114,7 @@ class StopView extends ViewFormBase<IStopViewProps, IStopViewState> {
                 isEditingDisabled={isEditingDisabled}
                 stopAreas={this.props.nodeStore!.stopAreaItems}
                 stopSections={this.state.stopSections}
-                stopInvalidPropertiesMap={this.state.invalidPropertiesMap}
+                stopInvalidPropertiesMap={invalidPropertiesMap}
                 nodeInvalidPropertiesMap={this.props.nodeInvalidPropertiesMap}
                 updateStopProperty={this.updateStopProperty}
                 onNodePropertyChange={onNodePropertyChange}

--- a/src/components/sidebar/nodeView/StopView.tsx
+++ b/src/components/sidebar/nodeView/StopView.tsx
@@ -29,7 +29,7 @@ interface IStopViewState {
 @observer
 class StopView extends React.Component<IStopViewProps, IStopViewState> {
     private nodeListener: IReactionDisposer;
-    private mounted: boolean;
+    private _isMounted: boolean;
 
     constructor(props: IStopViewProps) {
         super(props);
@@ -40,7 +40,7 @@ class StopView extends React.Component<IStopViewProps, IStopViewState> {
     }
 
     async componentDidMount() {
-        this.mounted = true;
+        this._isMounted = true;
         this.nodeListener = reaction(() => this.props.nodeStore!.node, this.onNodeChange);
         if (this.props.isNewStop) {
             this.props.nodeStore!.fetchAddressData();
@@ -48,7 +48,7 @@ class StopView extends React.Component<IStopViewProps, IStopViewState> {
         const stopAreas: IStopAreaItem[] = await StopAreaService.fetchAllStopAreas();
         const stopSections: IStopSectionItem[] = await StopService.fetchAllStopSections();
 
-        if (this.mounted) {
+        if (this._isMounted) {
             this.setState({
                 stopSections: this.createStopSectionDropdownItems(stopSections)
             });
@@ -58,7 +58,7 @@ class StopView extends React.Component<IStopViewProps, IStopViewState> {
     }
 
     componentWillUnmount() {
-        this.mounted = false;
+        this._isMounted = false;
         this.nodeListener();
     }
 

--- a/src/models/validationModels/lineValidationModel.ts
+++ b/src/models/validationModels/lineValidationModel.ts
@@ -5,6 +5,7 @@ import { ILine } from '..';
 type LineKeys = keyof ILine;
 type ILineValidationModel = { [key in LineKeys]: string };
 
+// TODO: rename as lineValidationObject
 const lineValidationModel: ILineValidationModel = {
     id: `required|min:4|max:6|string|${regexRules.upperCaseOrNumbersOrSpace}`,
     routes: '',
@@ -22,3 +23,5 @@ const lineValidationModel: ILineValidationModel = {
 };
 
 export default lineValidationModel;
+
+export { ILineValidationModel };

--- a/src/models/validationModels/nodeValidationModel.ts
+++ b/src/models/validationModels/nodeValidationModel.ts
@@ -21,3 +21,5 @@ const nodeValidationModel: INodeValidationModel = {
 };
 
 export default nodeValidationModel;
+
+export { INodeValidationModel };

--- a/src/models/validationModels/nodeValidationModel.ts
+++ b/src/models/validationModels/nodeValidationModel.ts
@@ -4,6 +4,7 @@ import { INode } from '..';
 type NodeKeys = keyof INode;
 type INodeValidationModel = { [key in NodeKeys]: string };
 
+// TODO: rename as nodeValidationObject
 const nodeValidationModel: INodeValidationModel = {
     id: '',
     type: 'required|min:1|max:1|string',

--- a/src/models/validationModels/stopValidationModel.ts
+++ b/src/models/validationModels/stopValidationModel.ts
@@ -10,6 +10,7 @@ const longNameRule = 'min:1|max:60|string';
 type StopKeys = keyof IStop;
 type IStopValidationModel = { [key in StopKeys]: string };
 
+// TODO: rename as stopValidationObject
 const stopValidationModel: IStopValidationModel = {
     nodeId: '',
     municipality: 'required|min:1|max:3|string',
@@ -35,3 +36,5 @@ const stopValidationModel: IStopValidationModel = {
 };
 
 export default stopValidationModel;
+
+export { IStopValidationModel };

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -17,7 +17,7 @@ export class LineStore {
 
     constructor() {
         this._isEditingDisabled = true;
-        this._validationStore = new ValidationStore(lineValidationModel);
+        this._validationStore = new ValidationStore();
 
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
     }
@@ -92,7 +92,7 @@ export class LineStore {
             }
         };
 
-        this._validationStore.init(line, customValidatorMap);
+        this._validationStore.init(line, lineValidationModel, customValidatorMap);
     };
 
     @action

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -1,14 +1,25 @@
 import _ from 'lodash';
-import { action, computed, observable } from 'mobx';
+import { action, computed, observable, reaction } from 'mobx';
 import { ILine } from '~/models';
+import ISearchLine from '~/models/searchModels/ISearchLine';
+import lineValidationModel, {
+    ILineValidationModel
+} from '~/models/validationModels/lineValidationModel';
+import { IValidationResult } from '~/validation/FormValidator';
+import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 export class LineStore {
     @observable private _line: ILine | null;
     @observable private _oldline: ILine | null;
     @observable private _isEditingDisabled: boolean;
+    @observable private _existingLines: ISearchLine[] = [];
+    private _validationStore: ValidationStore<ILine, ILineValidationModel>;
 
     constructor() {
         this._isEditingDisabled = true;
+        this._validationStore = new ValidationStore(lineValidationModel);
+
+        reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
     }
 
     @computed
@@ -26,11 +37,62 @@ export class LineStore {
         return this._isEditingDisabled;
     }
 
-    // TODO: rename as init
+    @computed
+    get existingLines() {
+        return this._existingLines;
+    }
+
+    @computed
+    get invalidPropertiesMap() {
+        return this._validationStore.getInvalidPropertiesMap();
+    }
+
+    @computed
+    get isLineFormValid() {
+        return this._validationStore.isValid();
+    }
+
     @action
-    public setLine = (line: ILine) => {
+    public init = (line: ILine) => {
         this._line = line;
         this.setOldLine(this._line);
+
+        const validateLineDates = (line: ILine) => {
+            // is end date before start date?
+            if (line.lineEndDate && line.lineEndDate.getTime() < line.lineStartDate.getTime()) {
+                const validationResult: IValidationResult = {
+                    isValid: false,
+                    errorMessage: `Viimeinen voimassaolopäivä ei voi olla ennen voimaanastumispäivää.`
+                };
+                return validationResult;
+            }
+            return;
+        };
+
+        const customValidatorMap: ICustomValidatorMap = {
+            id: {
+                validator: (line: ILine, property: string, lineId: string) => {
+                    if (this.isLineAlreadyFound(lineId)) {
+                        const validationResult: IValidationResult = {
+                            isValid: false,
+                            errorMessage: `Linja ${lineId} on jo olemassa.`
+                        };
+                        return validationResult;
+                    }
+                    return;
+                }
+            },
+            lineStartDate: {
+                validator: validateLineDates,
+                dependentProperties: ['lineEndDate']
+            },
+            lineEndDate: {
+                validator: validateLineDates,
+                dependentProperties: ['lineStartDate']
+            }
+        };
+
+        this._validationStore.init(line, customValidatorMap);
     };
 
     @action
@@ -44,6 +106,7 @@ export class LineStore {
             ...this._line!,
             [property]: value
         };
+        this._validationStore.updateProperty(property, value);
     };
 
     @action
@@ -57,14 +120,34 @@ export class LineStore {
     };
 
     @action
+    public setExistingLines = (existingLines: ISearchLine[]) => {
+        this._existingLines = existingLines;
+    };
+
+    @action
     public clear = () => {
         this._line = null;
+        this._validationStore.clear();
     };
 
     @action
     public resetChanges = () => {
         if (this._oldline) {
-            this.setLine(this._oldline);
+            this.init(this._oldline);
+        }
+    };
+
+    private isLineAlreadyFound = (lineId: string): boolean => {
+        return Boolean(
+            this.existingLines.find((searchLine: ISearchLine) => searchLine.id === lineId)
+        );
+    };
+
+    private onChangeIsEditingDisabled = () => {
+        if (this._isEditingDisabled) {
+            this.resetChanges();
+        } else {
+            this._validationStore.validateAllProperties();
         }
     };
 }

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -339,9 +339,6 @@ class NodeStore {
 
     @action
     public resetChanges = () => {
-        this._nodeValidationStore.clearInvalidPropertiesMap();
-        this._stopValidationStore.clearInvalidPropertiesMap();
-
         if (this._oldNode) {
             this.init({ node: this._oldNode, links: this._oldLinks, isNewNode: false });
         }

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -54,8 +54,8 @@ class NodeStore {
         this._oldNode = null;
         this._oldLinks = [];
         this._geometryUndoStore = new GeometryUndoStore();
-        this._nodeValidationStore = new ValidationStore(nodeValidationModel);
-        this._stopValidationStore = new ValidationStore(stopValidationModel);
+        this._nodeValidationStore = new ValidationStore();
+        this._stopValidationStore = new ValidationStore();
         this._isEditingDisabled = true;
         this._nodeCache = {
             newNodeCache: null
@@ -159,9 +159,9 @@ class NodeStore {
         this._oldLinks = oldLinks ? oldLinks : newLinks;
         this._isEditingDisabled = !isNewNode;
 
-        this._nodeValidationStore.init(node);
+        this._nodeValidationStore.init(node, nodeValidationModel);
         if (node.stop) {
-            this._stopValidationStore.init(node.stop);
+            this._stopValidationStore.init(node.stop, stopValidationModel);
         }
     };
 
@@ -273,17 +273,14 @@ class NodeStore {
         if (this._node.type === NodeType.STOP && !this._node.stop) {
             const stop = NodeStopFactory.createNewStop();
             (this._node as any)[property] = stop;
-            this._stopValidationStore.init(stop);
+            this._stopValidationStore.init(stop, stopValidationModel);
         }
     };
 
     @action
     public updateStopProperty = (property: string, value?: string | number | Date) => {
         if (!this.node) return;
-        this._node!.stop = {
-            ...this._node!.stop!,
-            [property]: value
-        };
+        this._node!.stop![property] = value;
         this._stopValidationStore.updateProperty(property, value);
     };
 

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -8,18 +8,16 @@ class ValidationStore<ValidationObject, ValidationModel> {
     private propertyListeners: IReactionDisposer[];
 
     constructor(validationModel: ValidationModel) {
+        this.propertyListeners = [];
         this.clear();
 
         this._validationModel = validationModel;
-        this.propertyListeners = [];
     }
 
     public init = (validationObject: ValidationObject) => {
         this._validationObject = validationObject;
 
-        if (this.propertyListeners.length > 0) {
-            this.removePropertyListeners();
-        }
+        this.removePropertyListeners();
         this.createPropertyListeners();
         this.validateAllProperties();
     };
@@ -79,6 +77,7 @@ class ValidationStore<ValidationObject, ValidationModel> {
     public clear = () => {
         this._validationObject = null;
         this._invalidPropertiesMap = {};
+        this.removePropertyListeners();
     };
 
     private createPropertyListeners = () => {
@@ -103,6 +102,7 @@ class ValidationStore<ValidationObject, ValidationModel> {
     };
 
     private removePropertyListeners = () => {
+        if (this.propertyListeners.length === 0) return;
         this.propertyListeners.forEach((listener: IReactionDisposer) => listener());
         this.propertyListeners = [];
     };

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -1,0 +1,111 @@
+import { observable, reaction, IReactionDisposer } from 'mobx';
+import FormValidator, { IValidationResult } from '~/validation/FormValidator';
+
+class ValidationStore<ValidationObject, ValidationModel> {
+    @observable private _validationObject: ValidationObject | null;
+    @observable private _invalidPropertiesMap: object;
+    @observable private _validationModel: ValidationModel;
+    private propertyListeners: IReactionDisposer[];
+
+    constructor(validationModel: ValidationModel) {
+        this.clear();
+
+        this._validationModel = validationModel;
+        this.propertyListeners = [];
+    }
+
+    public init = (validationObject: ValidationObject) => {
+        this._validationObject = validationObject;
+
+        if (this.propertyListeners.length > 0) {
+            this.removePropertyListeners();
+        }
+        this.createPropertyListeners();
+        this.validateAllProperties();
+    };
+
+    public updateProperty = (property: string, value: any) => {
+        this._validationObject![property] = value;
+    };
+
+    public validateProperty = (validatorRule: string, property: string, value: any) => {
+        if (!validatorRule) return;
+        const validatorResult: IValidationResult | undefined = FormValidator.validateProperty(
+            validatorRule,
+            value
+        );
+        if (validatorResult) {
+            this.setValidatorResult(property, validatorResult);
+        }
+    };
+
+    public setValidatorResult = (property: string, validatorResult: IValidationResult) => {
+        this._invalidPropertiesMap[property] = validatorResult;
+    };
+
+    public validateAllProperties = () => {
+        if (!this._validationObject) {
+            throw 'ValidationStore error: tried to validate an empty validationObject';
+        }
+
+        const invalidPropertiesMap: object = {};
+
+        Object.entries(this._validationModel).forEach(([property, validatorRule]) => {
+            const validationResult = FormValidator.validateProperty(
+                validatorRule,
+                this._validationObject![property]
+            );
+            if (validationResult) {
+                invalidPropertiesMap[property] = validationResult;
+            }
+        });
+        this._invalidPropertiesMap = invalidPropertiesMap;
+    };
+
+    public isValid = () => {
+        return !Object.values(this._invalidPropertiesMap).some(
+            validatorResult => !validatorResult.isValid
+        );
+    };
+
+    public getInvalidPropertiesMap = () => {
+        return this._invalidPropertiesMap;
+    };
+
+    public clearInvalidPropertiesMap = () => {
+        this._invalidPropertiesMap = {};
+    };
+
+    public clear = () => {
+        this._validationObject = null;
+        this._invalidPropertiesMap = {};
+    };
+
+    private createPropertyListeners = () => {
+        for (const property in this._validationObject!) {
+            if (Object.prototype.hasOwnProperty.call(this._validationObject, property)) {
+                const listener = this.initPropertyListener(property);
+                this.propertyListeners.push(listener);
+            }
+        }
+    };
+
+    private initPropertyListener = (property: string): IReactionDisposer => {
+        return reaction(
+            () => this._validationObject && this._validationObject[property],
+            () =>
+                this.validateProperty(
+                    this._validationModel[property],
+                    property,
+                    this._validationObject![property]
+                )
+        );
+    };
+
+    private removePropertyListeners = () => {
+        this.propertyListeners.forEach((listener: IReactionDisposer) => listener());
+        this.propertyListeners = [];
+    };
+}
+
+export default ValidationStore;

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -10,6 +10,10 @@ interface ICustomValidatorMap {
     [key: string]: ICustomValidatorObject;
 }
 
+/**
+ * @param {Object} ValidationObject - object to validate (e.g. ILink)
+ * @param {Object} ValidationModel - { property: string}, where property = validation string (e.g. IValidationModel)
+ */
 class ValidationStore<ValidationObject, ValidationModel> {
     @observable private _validationObject: ValidationObject | null;
     @observable private _invalidPropertiesMap: object;

--- a/src/validation/FormValidator.ts
+++ b/src/validation/FormValidator.ts
@@ -27,6 +27,7 @@ Validator.register(
     'Koordinaatti sallittujen rajojen ulkopuolella.'
 );
 
+// TODO: remove this class, use validationStore instead.
 class FormValidator {
     public static validate = (value: any, rule: string): IValidationResult => {
         const validator = new Validator(

--- a/src/validation/FormValidator.ts
+++ b/src/validation/FormValidator.ts
@@ -27,7 +27,6 @@ Validator.register(
     'Koordinaatti sallittujen rajojen ulkopuolella.'
 );
 
-// TODO: remove this class, use validationStore instead.
 class FormValidator {
     public static validate = (value: any, rule: string): IValidationResult => {
         const validator = new Validator(


### PR DESCRIPTION
Notified that there are common things in all Views:
* isEditingDisabled change -> have to call validateAllProperties()
* object to validate (eg. ILink)
    * object properties have to have listeners and they have to be validated when they change
         * when a object to validate changes, existing listeners need to be removed
    * need access to validation result
* validation model (eg. ILinkValidationModel)
* invalidPropertiesMap
    * some properties may require custom validation functions where result depends on values of other objects. Some properties may require other properties to validate when they are validated

--> implemented a generic ValidationStore to handle these requirements.

When user puts a letter into inputContainer, currenly flow goes like this:
InputContainer -> StopView -> StopStore (update stop property) -> ValidationStore -> StopStore (updated invalidPropertiesMap)-> Stop View -> InputContainer (props.value is updated)

How to test:
* test that nodeView works (stop & node form)
* test that lineView works
* test that switching fast between nodeViews doesn't cause any warnings / thrown errors