### PR TITLE
1169 stop using ViewFormBase in linkView, routePathView, stopAreaView

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,6 +60,7 @@ class App extends React.Component<IAppProps, IAppState> {
             <>
                 <NavigationBar />
                 <div className={s.appContent}>
+                    {/* Map needs to be rendered before <Sidebar /> so that listeners get initialized before Views set map coordinates. */}
                     <Map>
                         <ErrorBar />
                     </Map>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -60,10 +60,10 @@ class App extends React.Component<IAppProps, IAppState> {
             <>
                 <NavigationBar />
                 <div className={s.appContent}>
-                    <Sidebar />
                     <Map>
                         <ErrorBar />
                     </Map>
+                    <Sidebar />
                 </div>
                 <OverlayContainer />
             </>

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -5,7 +5,7 @@
 
     .appContent {
         display: flex;
-        flex-direction: row;
+        flex-direction: row-reverse;
         height: 100%;
         overflow-y: auto;
     }

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -1,18 +1,15 @@
 import classnames from 'classnames';
 import L from 'leaflet';
-import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { FiChevronLeft, FiChevronRight } from 'react-icons/fi';
 import { RouteComponentProps } from 'react-router-dom';
 import SavePrompt, { ISaveModel } from '~/components/overlays/SavePrompt';
-import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import Loader from '~/components/shared/loader/Loader';
 import ButtonType from '~/enums/buttonType';
 import TransitType from '~/enums/transitType';
 import LinkFactory from '~/factories/linkFactory';
 import { ILink, INode } from '~/models';
-import linkValidationModel from '~/models/validationModels/linkValidationModel';
 import navigator from '~/routing/navigator';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
@@ -43,20 +40,17 @@ interface ILinkViewProps extends RouteComponentProps<any> {
 
 interface ILinkViewState {
     isLoading: boolean;
-    invalidPropertiesMap: object;
 }
 
 @inject('linkStore', 'mapStore', 'errorStore', 'alertStore', 'codeListStore', 'confirmStore')
 @observer
-class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
-    private isEditingDisabledListener: IReactionDisposer;
+class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
     private existingTransitTypes: TransitType[] = [];
 
     constructor(props: ILinkViewProps) {
         super(props);
         this.state = {
-            isLoading: false,
-            invalidPropertiesMap: {}
+            isLoading: false
         };
     }
 
@@ -67,14 +61,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         } else {
             await this.initExistingLink();
         }
-        if (this.props.linkStore!.link) {
-            this.validateLink();
-        }
         this.props.linkStore!.setIsEditingDisabled(!this.props.isNewLink);
-        this.isEditingDisabledListener = reaction(
-            () => this.props.linkStore!.isEditingDisabled,
-            this.onChangeIsEditingDisabled
-        );
         EventManager.on('geometryChange', () => this.props.linkStore!.setIsEditingDisabled(false));
     }
 
@@ -90,7 +77,6 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
     componentWillUnmount() {
         this.props.linkStore!.clear();
-        this.isEditingDisabledListener();
         EventManager.off('geometryChange', () => this.props.linkStore!.setIsEditingDisabled(false));
     }
 
@@ -142,7 +128,6 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         if (existingLinks.length > 0) {
             this.existingTransitTypes = existingLinks.map(link => link.transitType!);
         }
-        this.validateLink();
 
         this.setState({ isLoading: false });
     };
@@ -198,17 +183,6 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         });
     };
 
-    private onChangeIsEditingDisabled = () => {
-        this.clearInvalidPropertiesMap();
-        const linkStore = this.props.linkStore;
-        if (linkStore!.isEditingDisabled) {
-            linkStore!.resetChanges();
-        } else {
-            linkStore!.updateLinkLength();
-            this.validateLink();
-        }
-    };
-
     private navigateToNewLink = () => {
         const link = this.props.linkStore!.link;
         const linkViewLink = routeBuilder
@@ -226,13 +200,8 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         navigator.goTo(editNetworkLink);
     };
 
-    private validateLink = () => {
-        this.validateAllProperties(linkValidationModel, this.props.linkStore!.link);
-    };
-
     private selectTransitType = (transitType: TransitType) => {
         this.props.linkStore!.updateLinkProperty('transitType', transitType);
-        this.validateProperty(linkValidationModel['transitType'], 'transitType', transitType);
     };
 
     private transitTypeAlreadyExists = (transitType: TransitType) => {
@@ -243,12 +212,10 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
 
     private onChangeLinkProperty = (property: keyof ILink) => (value: any) => {
         this.props.linkStore!.updateLinkProperty(property, value);
-        this.validateProperty(linkValidationModel[property], property, value);
     };
 
     render() {
         const link = this.props.linkStore!.link;
-        const invalidPropertiesMap = this.state.invalidPropertiesMap;
         if (this.state.isLoading) {
             return (
                 <div className={classnames(s.linkView, s.loaderContainer)}>
@@ -259,6 +226,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
         // TODO: show some indicator to user of an empty page
         if (!link) return null;
 
+        const invalidPropertiesMap = this.props.linkStore!.invalidPropertiesMap;
         const isEditingDisabled = this.props.linkStore!.isEditingDisabled;
         const startNode = link!.startNode;
         const endNode = link!.endNode;
@@ -270,7 +238,7 @@ class LinkView extends ViewFormBase<ILinkViewProps, ILinkViewState> {
             isEditingDisabled ||
             !this.props.linkStore!.isDirty ||
             (this.props.isNewLink && this.transitTypeAlreadyExists(transitType)) ||
-            !this.isFormValid();
+            !this.props.linkStore!.isFormValid;
         const selectedTransitTypes = link!.transitType ? [link!.transitType!] : [];
 
         let transitTypeError;

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -1,17 +1,14 @@
 import classnames from 'classnames';
-import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { match } from 'react-router';
 import { IDropdownItem } from '~/components/controls/Dropdown';
 import SavePrompt, { ISaveModel } from '~/components/overlays/SavePrompt';
-import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import Loader from '~/components/shared/loader/Loader';
 import ButtonType from '~/enums/buttonType';
 import TransitType from '~/enums/transitType';
 import StopAreaFactory from '~/factories/stopAreaFactory';
 import { IStopArea } from '~/models';
-import stopAreaValidationModel from '~/models/validationModels/stopAreaValidationModel';
 import navigator from '~/routing/navigator';
 import QueryParams from '~/routing/queryParams';
 import routeBuilder from '~/routing/routeBuilder';
@@ -45,7 +42,6 @@ interface IStopAreaViewProps {
 
 interface IStopAreaViewState {
     isLoading: boolean;
-    invalidPropertiesMap: object;
     terminalAreas: IDropdownItem[];
 }
 
@@ -59,22 +55,16 @@ interface IStopAreaViewState {
     'mapStore'
 )
 @observer
-class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> {
-    private isEditingDisabledListener: IReactionDisposer;
-    private stopAreaPropertyListeners: IReactionDisposer[];
+class StopAreaView extends React.Component<IStopAreaViewProps, IStopAreaViewState> {
     private mounted: boolean;
-    private listenersSet: boolean;
 
     constructor(props: IStopAreaViewProps) {
         super(props);
         this.state = {
             isLoading: false,
-            invalidPropertiesMap: {},
             terminalAreas: []
         };
-        this.stopAreaPropertyListeners = [];
         this.mounted = false;
-        this.listenersSet = false;
     }
 
     async componentDidMount() {
@@ -86,14 +76,7 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
             await this.initExistingStopArea();
         }
 
-        if (this.props.stopAreaStore!.stopArea) {
-            this.validateStopArea();
-        }
         this.props.stopAreaStore!.setIsEditingDisabled(!this.props.isNewStopArea);
-        this.isEditingDisabledListener = reaction(
-            () => this.props.stopAreaStore!.isEditingDisabled,
-            this.onChangeIsEditingDisabled
-        );
         const terminalAreas: ITerminalAreaItem[] = await StopAreaService.fetchAllTerminalAreas();
 
         if (this.mounted) {
@@ -101,7 +84,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                 terminalAreas: this.createTerminalAreaDropdownItems(terminalAreas)
             });
         }
-        this.listenersSet = true;
     }
 
     componentDidUpdate(prevProps: IStopAreaViewProps) {
@@ -118,11 +100,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
     componentWillUnmount() {
         this.mounted = false;
         this.props.stopAreaStore!.clear();
-        // TODO: move property validation into store so that these listeners wouldn't be needed at the component
-        if (this.listenersSet) {
-            this.isEditingDisabledListener();
-            this.removeNodePropertyListeners();
-        }
     }
 
     private initExistingStopArea = async () => {
@@ -136,9 +113,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                     stopArea,
                     isNewStopArea: false
                 });
-
-                this.validateStopArea();
-                this.createStopAreaPropertyListeners();
             }
         } catch (e) {
             this.props.errorStore!.addError(
@@ -158,33 +132,7 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
             isNewStopArea: true
         });
 
-        this.validateStopArea();
-        this.createStopAreaPropertyListeners();
-
         this.setState({ isLoading: false });
-    };
-
-    private createStopAreaPropertyListeners = () => {
-        const stopArea: IStopArea = this.props.stopAreaStore!.stopArea;
-        if (!stopArea) return;
-
-        for (const property in stopArea) {
-            const listener = this.createStopAreaPropertyListener(property);
-            this.stopAreaPropertyListeners.push(listener);
-        }
-    };
-
-    private createStopAreaPropertyListener = (property: string) => {
-        return reaction(
-            () =>
-                this.props.stopAreaStore!.stopArea && this.props.stopAreaStore!.stopArea![property],
-            this.validateStopAreaProperty(property)
-        );
-    };
-
-    private removeNodePropertyListeners = () => {
-        this.stopAreaPropertyListeners.forEach((listener: IReactionDisposer) => listener());
-        this.stopAreaPropertyListeners = [];
     };
 
     private save = async () => {
@@ -244,32 +192,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
         });
     };
 
-    private onChangeIsEditingDisabled = () => {
-        if (!this.mounted) return;
-
-        this.clearInvalidPropertiesMap();
-        const stopAreaStore = this.props.stopAreaStore;
-        if (stopAreaStore!.isEditingDisabled) {
-            stopAreaStore!.resetChanges();
-        } else {
-            this.validateStopArea();
-        }
-    };
-
-    private validateStopArea = () => {
-        this.validateAllProperties(stopAreaValidationModel, this.props.stopAreaStore!.stopArea);
-    };
-
-    private validateStopAreaProperty = (property: string) => () => {
-        if (!this.mounted) return;
-
-        const stopArea = this.props.stopAreaStore!.stopArea;
-        if (!stopArea) return;
-
-        const value = stopArea[property];
-        this.validateProperty(stopAreaValidationModel[property], property, value);
-    };
-
     private createTerminalAreaDropdownItems = (
         terminalAreas: ITerminalAreaItem[]
     ): IDropdownItem[] => {
@@ -284,7 +206,6 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
 
     private selectTransitType = (transitType: TransitType) => {
         this.props.stopAreaStore!.updateStopAreaProperty('transitType', transitType);
-        this.validateProperty(stopAreaValidationModel['transitType'], 'transitType', transitType);
     };
 
     private onChangeStopAreaProperty = (property: keyof IStopArea) => (value: any) => {
@@ -292,8 +213,9 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
     };
 
     render() {
-        const stopArea = this.props.stopAreaStore!.stopArea;
-        const invalidPropertiesMap = this.state.invalidPropertiesMap;
+        const stopAreaStore = this.props.stopAreaStore!;
+        const stopArea = stopAreaStore.stopArea;
+        const invalidPropertiesMap = stopAreaStore.invalidPropertiesMap;
         if (this.state.isLoading) {
             return (
                 <div className={classnames(s.stopAreaView, s.loaderContainer)}>
@@ -303,14 +225,14 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
         }
         if (!stopArea) return null;
 
-        const isEditingDisabled = this.props.stopAreaStore!.isEditingDisabled;
-        const transitType = this.props.stopAreaStore!.stopArea.transitType;
+        const isEditingDisabled = stopAreaStore.isEditingDisabled;
+        const transitType = stopAreaStore.stopArea.transitType;
 
         const isSaveButtonDisabled =
             !transitType ||
             isEditingDisabled ||
-            !this.props.stopAreaStore!.isDirty ||
-            !this.isFormValid();
+            !stopAreaStore.isDirty ||
+            !stopAreaStore.isFormValid;
         const selectedTransitTypes = stopArea!.transitType ? [stopArea!.transitType!] : [];
 
         let transitTypeError;
@@ -323,8 +245,8 @@ class StopAreaView extends ViewFormBase<IStopAreaViewProps, IStopAreaViewState> 
                     <SidebarHeader
                         isEditButtonVisible={!this.props.isNewStopArea}
                         isEditing={!isEditingDisabled}
-                        shouldShowClosePromptMessage={this.props.stopAreaStore!.isDirty!}
-                        onEditButtonClick={this.props.stopAreaStore!.toggleIsEditingDisabled}
+                        shouldShowClosePromptMessage={stopAreaStore.isDirty!}
+                        onEditButtonClick={stopAreaStore.toggleIsEditingDisabled}
                     >
                         {this.props.isNewStopArea ? 'Luo uusi pysäkkialue' : 'Pysäkkialue'}
                     </SidebarHeader>

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -279,6 +279,7 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
         }
         if (redirectUrl) {
             navigator.goTo(redirectUrl);
+            return;
         }
         await this.fetchRoutePath();
         this.setState({

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -100,6 +100,8 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
     };
 
     private createNewRoutePath = async () => {
+        this.props.mapStore!.setIsMapCenteringPrevented(false);
+        this.props.mapStore!.initCoordinates();
         try {
             if (!this.props.routePathStore!.routePath) {
                 const queryParams = navigator.getQueryParamValues();
@@ -107,7 +109,6 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
                 const lineId = queryParams[QueryParams.lineId];
                 const route = await RouteService.fetchRoute(routeId);
                 const routePath = RoutePathFactory.createNewRoutePath(lineId, route);
-                this.centerMapToRoutePath(routePath);
                 this.props.routePathStore!.init(routePath, []);
             } else {
                 this.props.routePathStore!.init(

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
@@ -3,7 +3,6 @@ import { inject, observer } from 'mobx-react';
 import React from 'react';
 import CalculatedInputField from '~/components/controls/CalculatedInputField';
 import { ILink, IRoutePath } from '~/models';
-import { IRoutePathPrimaryKey } from '~/models/IRoutePath';
 import navigator from '~/routing/navigator';
 import QueryParams from '~/routing/queryParams';
 import routeBuilder from '~/routing/routeBuilder';
@@ -12,7 +11,6 @@ import LinkService from '~/services/linkService';
 import RoutePathService from '~/services/routePathService';
 import { CodeListStore } from '~/stores/codeListStore';
 import { RoutePathStore } from '~/stores/routePathStore';
-import { IValidationResult } from '~/validation/FormValidator';
 import ButtonType from '../../../../enums/buttonType';
 import { Button, Dropdown } from '../../../controls';
 import InputContainer from '../../../controls/InputContainer';
@@ -26,9 +24,7 @@ interface IRoutePathInfoTabProps {
     isEditingDisabled: boolean;
     routePath: IRoutePath;
     isNewRoutePath: boolean;
-    onChangeRoutePathProperty: (property: keyof IRoutePath) => (value: any) => void;
     invalidPropertiesMap: object;
-    setValidatorResult: (property: string, validationResult: IValidationResult) => void;
 }
 
 interface IRoutePathInfoTabState {
@@ -39,7 +35,6 @@ interface IRoutePathInfoTabState {
 @observer
 class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePathInfoTabState> {
     private isRoutePathLinksChangedListener: IReactionDisposer;
-    private existingRoutePathPrimaryKeys: IRoutePathPrimaryKey[];
     private mounted: boolean;
 
     constructor(props: IRoutePathInfoTabProps) {
@@ -100,9 +95,8 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
     };
 
     private fetchExistingPrimaryKeys = async (routeId: string) => {
-        this.existingRoutePathPrimaryKeys = await RoutePathService.fetchAllRoutePathPrimaryKeys(
-            routeId
-        );
+        const routePathPrimaryKeys = await RoutePathService.fetchAllRoutePathPrimaryKeys(routeId);
+        this.props.routePathStore!.setExistingRoutePathPrimaryKeys(routePathPrimaryKeys);
     };
 
     private showAlertPlanningInProgress = () => {
@@ -138,47 +132,15 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
         return length;
     };
 
-    private isPrimaryKeyDuplicated = () => {
-        const routePath = this.props.routePathStore!.routePath!;
-
-        return this.existingRoutePathPrimaryKeys.some(
-            rp =>
-                routePath.routeId === rp.routeId &&
-                routePath.direction === rp.direction &&
-                routePath.startTime.getTime() === rp.startTime.getTime()
-        );
-    };
-
-    private validatePrimaryKey = () => {
-        if (this.props.isNewRoutePath && this.isPrimaryKeyDuplicated()) {
-            const validationResult: IValidationResult = {
-                isValid: false,
-                errorMessage:
-                    'Reitinsuunta samalla reitillä, suunnalla ja alkupäivämäärällä on jo olemassa.'
-            };
-            this.props.setValidatorResult('direction', validationResult);
-        }
-    };
-
-    private onChangeDirection = (direction: string) => {
-        const startTime = this.props.routePathStore!.routePath!.startTime;
-        this.props.onChangeRoutePathProperty('direction')(direction);
-        this.props.onChangeRoutePathProperty('startTime')(startTime);
-        this.validatePrimaryKey();
-    };
-
-    private onChangeStartTime = (startTime: Date) => {
-        const direction = this.props.routePathStore!.routePath!.direction;
-        this.props.onChangeRoutePathProperty('direction')(direction);
-        this.props.onChangeRoutePathProperty('startTime')(startTime);
-        this.validatePrimaryKey();
+    private onChangeRoutePathProperty = (property: keyof IRoutePath) => (value: any) => {
+        this.props.routePathStore!.updateRoutePathProperty(property, value);
     };
 
     render() {
         const isEditingDisabled = this.props.isEditingDisabled;
         const isUpdating = !this.props.isNewRoutePath || this.props.isEditingDisabled;
         const invalidPropertiesMap = this.props.invalidPropertiesMap;
-        const onChange = this.props.onChangeRoutePathProperty;
+        const onChange = this.onChangeRoutePathProperty;
         const routePath = this.props.routePath;
         return (
             <div className={s.routePathInfoTabView}>
@@ -254,7 +216,7 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
                                 disabled={isUpdating}
                                 type='date'
                                 value={routePath.startTime}
-                                onChange={this.onChangeStartTime}
+                                onChange={onChange('startTime')}
                                 validationResult={invalidPropertiesMap['startTime']}
                             />
                             <InputContainer
@@ -281,7 +243,7 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
                                 disabled={isUpdating}
                                 selected={this.props.routePath.direction}
                                 items={this.props.codeListStore!.getDropdownItemList('Suunta')}
-                                onChange={this.onChangeDirection}
+                                onChange={onChange('direction')}
                                 validationResult={invalidPropertiesMap['direction']}
                             />
                             <Dropdown

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
@@ -31,20 +31,9 @@ interface IRoutePathListNodeProps {
     isLastNode?: boolean;
 }
 
-interface RoutePathListNodeState {
-    isLoading: boolean; // not currently in use, declared because ViewFormBase needs this
-}
-
 @inject('routePathStore', 'codeListStore')
 @observer
-class RoutePathListNode extends React.Component<IRoutePathListNodeProps, RoutePathListNodeState> {
-    constructor(props: IRoutePathListNodeProps) {
-        super(props);
-        this.state = {
-            isLoading: false
-        };
-    }
-
+class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
     private renderHeader = () => {
         const node = this.props.node;
         const stopName = node.stop ? node.stop.nameFi : '';

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
@@ -5,13 +5,10 @@ import React from 'react';
 import { FaAngleDown, FaAngleRight } from 'react-icons/fa';
 import { FiChevronRight } from 'react-icons/fi';
 import { Button, Checkbox, Dropdown } from '~/components/controls';
-import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
 import ButtonType from '~/enums/buttonType';
 import NodeType from '~/enums/nodeType';
 import StartNodeType from '~/enums/startNodeType';
-import { INode, IRoutePathLink, IStop, IViaName } from '~/models';
-import routePathLinkValidationModel from '~/models/validationModels/routePathLinkValidationModel';
-import viaNameValidationModel from '~/models/validationModels/viaNameValidationModel';
+import { INode, IRoutePathLink, IStop } from '~/models';
 import navigator from '~/routing/navigator';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
@@ -19,7 +16,6 @@ import { CodeListStore } from '~/stores/codeListStore';
 import { RoutePathStore } from '~/stores/routePathStore';
 import NodeHelper from '~/util/NodeHelper';
 import TransitTypeHelper from '~/util/TransitTypeHelper';
-import FormValidator, { IValidationResult } from '~/validation/FormValidator';
 import InputContainer from '../../../controls/InputContainer';
 import TextContainer from '../../../controls/TextContainer';
 import RoutePathListItem from './RoutePathListItem';
@@ -37,69 +33,17 @@ interface IRoutePathListNodeProps {
 
 interface RoutePathListNodeState {
     isLoading: boolean; // not currently in use, declared because ViewFormBase needs this
-    invalidPropertiesMap: object;
-    isEditingDisabled: boolean; // not currently in use, declared because ViewFormBase needs this
 }
 
 @inject('routePathStore', 'codeListStore')
 @observer
-class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathListNodeState> {
+class RoutePathListNode extends React.Component<IRoutePathListNodeProps, RoutePathListNodeState> {
     constructor(props: IRoutePathListNodeProps) {
         super(props);
         this.state = {
-            isLoading: false,
-            invalidPropertiesMap: {},
-            isEditingDisabled: false
+            isLoading: false
         };
     }
-
-    componentDidMount() {
-        this.validateLink();
-    }
-
-    componentDidUpdate(prevProps: IRoutePathListNodeProps) {
-        if (prevProps.isEditingDisabled && !this.props.isEditingDisabled) {
-            this.validateLink();
-        }
-    }
-
-    private validateLink = () => {
-        this.validateAllProperties(routePathLinkValidationModel, this.props.routePathLink);
-        const orderNumber = this.props.routePathLink.orderNumber;
-
-        let isViaNameValid = true;
-        if (!this.props.isLastNode) {
-            const viaName = this.props.routePathStore!.getViaName(this.props.routePathLink.id);
-            if (viaName) {
-                isViaNameValid = this.validateViaNames(viaName);
-            }
-        }
-
-        const isLinkFormValid = this.isFormValid() && isViaNameValid;
-
-        this.props.routePathStore!.setLinkFormValidity(orderNumber, isLinkFormValid);
-    };
-
-    private validateViaNames = (viaName: IViaName) => {
-        const attributeNames = [
-            'destinationFi1',
-            'destinationSw1',
-            'destinationFi2',
-            'destinationSw2'
-        ];
-
-        let isValid = true;
-        attributeNames.forEach((attribute: string) => {
-            const validationResult: IValidationResult = FormValidator.validate(
-                viaName[attribute],
-                viaNameValidationModel[attribute]
-            );
-            this.setValidatorResult(attribute, validationResult);
-            if (!validationResult.isValid) isValid = false;
-        });
-
-        return isValid;
-    };
 
     private renderHeader = () => {
         const node = this.props.node;
@@ -137,11 +81,7 @@ class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathL
 
     private onRoutePathLinkPropertyChange = (property: keyof IRoutePathLink) => (value: any) => {
         const orderNumber = this.props.routePathLink.orderNumber;
-
         this.props.routePathStore!.updateRoutePathLinkProperty(orderNumber, property, value);
-        this.validateProperty(routePathLinkValidationModel[property], property, value);
-        const isLinkFormValid = this.isFormValid();
-        this.props.routePathStore!.setLinkFormValidity(orderNumber, isLinkFormValid);
     };
 
     /**
@@ -159,27 +99,6 @@ class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathL
         } else {
             this.props.routePathStore!.updateRoutePathLinkProperty(orderNumber, property, value);
         }
-        this.validateProperty(routePathLinkValidationModel[property], property, value);
-        const isLinkFormValid = this.isFormValid();
-        this.props.routePathStore!.setLinkFormValidity(orderNumber, isLinkFormValid);
-    };
-
-    private onViaNameChange = (value: string, attributeName: string) => {
-        const routePathLinkId = this.props.routePathLink.id;
-        let viaName = _.cloneDeep(this.props.routePathStore!.getViaName(routePathLinkId));
-
-        if (!viaName) {
-            viaName = {
-                id: `${routePathLinkId}`,
-                destinationFi1: '',
-                destinationFi2: '',
-                destinationSw1: '',
-                destinationSw2: ''
-            };
-        }
-        viaName[attributeName] = value;
-        this.props.routePathStore!.setViaName(viaName);
-        this.validateLink();
     };
 
     private onIsStartNodeUsingBookScheduleChange = (value: boolean) => () => {
@@ -188,17 +107,18 @@ class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathL
 
     private renderStopView = (stop: IStop) => {
         const isEditingDisabled = this.props.isEditingDisabled;
-        const invalidPropertiesMap = this.state.invalidPropertiesMap;
-
         const routePath = this.props.routePathStore!.routePath;
         const routePathLink = this.props.routePathLink;
-        const viaName = this.props.routePathStore!.getViaName(routePathLink.id);
         const isStartNodeUsingBookSchedule = this.props.isLastNode
             ? routePath!.isStartNodeUsingBookSchedule
             : routePathLink.isStartNodeUsingBookSchedule;
         const startNodeBookScheduleColumnNumber = this.props.isLastNode
             ? routePath!.startNodeBookScheduleColumnNumber
             : routePathLink.startNodeBookScheduleColumnNumber;
+
+        const invalidPropertiesMap = this.props.routePathStore!.getRoutePathLinkInvalidPropertiesMap(
+            routePathLink.id
+        );
 
         return (
             <div>
@@ -262,17 +182,17 @@ class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathL
                             <InputContainer
                                 label='1. MÄÄRÄNPÄÄ SUOMEKSI'
                                 disabled={isEditingDisabled}
-                                value={viaName ? viaName.destinationFi1 : ''}
+                                value={routePathLink.destinationFi1}
                                 validationResult={invalidPropertiesMap['destinationFi1']}
-                                onChange={e => this.onViaNameChange(e, 'destinationFi1')}
+                                onChange={this.onRoutePathLinkPropertyChange('destinationFi1')}
                                 darkerInputLabel={true}
                             />
                             <InputContainer
                                 label='2. MÄÄRÄNPÄÄ SUOMEKSI'
                                 disabled={isEditingDisabled}
-                                value={viaName ? viaName.destinationFi2 : ''}
+                                value={routePathLink.destinationFi2}
                                 validationResult={invalidPropertiesMap['destinationFi2']}
-                                onChange={e => this.onViaNameChange(e, 'destinationFi2')}
+                                onChange={this.onRoutePathLinkPropertyChange('destinationFi2')}
                                 darkerInputLabel={true}
                             />
                         </div>
@@ -280,17 +200,17 @@ class RoutePathListNode extends ViewFormBase<IRoutePathListNodeProps, RoutePathL
                             <InputContainer
                                 label='1. MÄÄRÄNPÄÄ RUOTSIKSI'
                                 disabled={isEditingDisabled}
-                                value={viaName ? viaName.destinationSw1 : ''}
+                                value={routePathLink.destinationSw1}
                                 validationResult={invalidPropertiesMap['destinationSw1']}
-                                onChange={e => this.onViaNameChange(e, 'destinationSw1')}
+                                onChange={this.onRoutePathLinkPropertyChange('destinationSw1')}
                                 darkerInputLabel={true}
                             />
                             <InputContainer
                                 label='2. MÄÄRÄNPÄÄ RUOTSIKSI'
                                 disabled={isEditingDisabled}
-                                value={viaName ? viaName.destinationSw2 : ''}
+                                value={routePathLink.destinationSw2}
                                 validationResult={invalidPropertiesMap['destinationSw2']}
-                                onChange={e => this.onViaNameChange(e, 'destinationSw2')}
+                                onChange={this.onRoutePathLinkPropertyChange('destinationSw2')}
                                 darkerInputLabel={true}
                             />
                         </div>

--- a/src/models/IRoutePathLink.ts
+++ b/src/models/IRoutePathLink.ts
@@ -20,6 +20,12 @@ export default interface IRoutePathLink extends IRoutePathLinkPrimaryKey {
     startNodeBookScheduleColumnNumber?: number;
     modifiedBy?: string;
     modifiedOn?: Date;
+    // IViaName properties
+    viaNameId?: string;
+    destinationFi1?: string;
+    destinationFi2?: string;
+    destinationSw1?: string;
+    destinationSw2?: string;
 }
 
 export { IRoutePathLinkPrimaryKey };

--- a/src/models/validationModels/linkValidationModel.ts
+++ b/src/models/validationModels/linkValidationModel.ts
@@ -4,6 +4,7 @@ import { ILink } from '..';
 type LinkKeys = keyof ILink;
 type ILinkValidationModel = { [key in LinkKeys]: string };
 
+// TODO: rename as linkValidationObject
 const linkValidationModel: ILinkValidationModel = {
     transitType: '',
     startNode: '',
@@ -17,3 +18,5 @@ const linkValidationModel: ILinkValidationModel = {
 };
 
 export default linkValidationModel;
+
+export { ILinkValidationModel };

--- a/src/models/validationModels/routePathLinkValidationModel.ts
+++ b/src/models/validationModels/routePathLinkValidationModel.ts
@@ -18,7 +18,14 @@ const routePathLinkValidationModel: IRoutePathLinkValidationModel = {
     isStartNodeUsingBookSchedule: 'boolean',
     startNodeBookScheduleColumnNumber: 'numeric|min:1|max:99',
     modifiedBy: '',
-    modifiedOn: ''
+    modifiedOn: '',
+    viaNameId: `string`,
+    destinationFi1: 'max:30|string',
+    destinationFi2: 'max:30|string',
+    destinationSw1: 'max:30|string',
+    destinationSw2: 'max:30|string'
 };
 
 export default routePathLinkValidationModel;
+
+export { IRoutePathLinkValidationModel };

--- a/src/models/validationModels/routePathValidationModel.ts
+++ b/src/models/validationModels/routePathValidationModel.ts
@@ -13,6 +13,7 @@ type RoutePathKeys = keyof Pick<
 >;
 type IRoutePathValidationModel = { [key in RoutePathKeys]: string };
 
+// TODO: rename as routePathValidationObject
 const routePathValidationModel: IRoutePathValidationModel = {
     routePathLinks: '',
     routeId: 'required|min:4|max:6|string',
@@ -36,3 +37,5 @@ const routePathValidationModel: IRoutePathValidationModel = {
 };
 
 export default routePathValidationModel;
+
+export { IRoutePathValidationModel };

--- a/src/models/validationModels/stopAreaValidationModel.ts
+++ b/src/models/validationModels/stopAreaValidationModel.ts
@@ -17,3 +17,5 @@ const stopAreaValidationModel: IStopAreaValidationModel = {
 };
 
 export default stopAreaValidationModel;
+
+export { IStopAreaValidationModel };

--- a/src/services/routePathService.ts
+++ b/src/services/routePathService.ts
@@ -61,19 +61,19 @@ class RoutePathService {
         );
     };
 
-    public static updateRoutePath = async (routePath: IRoutePath, viaNames: IViaName[]) => {
+    public static updateRoutePath = async (routePath: IRoutePath) => {
         const requestBody = {
             routePath,
-            viaNames
+            viaNames: _getViaNames(routePath)
         };
 
         await ApiClient.updateObject(endpoints.ROUTEPATH, requestBody);
     };
 
-    public static createRoutePath = async (routePath: IRoutePath, viaNames: IViaName[]) => {
+    public static createRoutePath = async (routePath: IRoutePath) => {
         const requestBody = {
             routePath,
-            viaNames
+            viaNames: _getViaNames(routePath)
         };
         const response = (await ApiClient.createObject(
             endpoints.ROUTEPATH,
@@ -82,5 +82,22 @@ class RoutePathService {
         return response;
     };
 }
+
+const _getViaNames = (routePath: IRoutePath) => {
+    const viaNames: IViaName[] = [];
+    routePath.routePathLinks.forEach(rpLink => {
+        if (rpLink.viaNameId) {
+            const viaName: IViaName = {
+                id: rpLink.viaNameId,
+                destinationFi1: rpLink.destinationFi1,
+                destinationFi2: rpLink.destinationFi2,
+                destinationSw1: rpLink.destinationSw1,
+                destinationSw2: rpLink.destinationSw2
+            };
+            viaNames.push(viaName);
+        }
+    });
+    return viaNames;
+};
 
 export default RoutePathService;

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -102,10 +102,7 @@ export class LineStore {
 
     @action
     public updateLineProperty = (property: keyof ILine, value: string | number | Date) => {
-        this._line = {
-            ...this._line!,
-            [property]: value
-        };
+        (this._line as any)[property] = value;
         this._validationStore.updateProperty(property, value);
     };
 

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -106,7 +106,9 @@ export class MapStore {
 
     @action
     public initCoordinates = () => {
-        this._coordinates = INITIAL_COORDINATES;
+        if (!this._coordinates) {
+            this._coordinates = INITIAL_COORDINATES;
+        }
     };
 
     @action

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -264,7 +264,6 @@ class NodeStore {
     public updateNodeProperty = (property: keyof INode, value: string | Date | LatLng) => {
         if (!this._node) return;
 
-        // As any to fix typing error: Type 'string' is not assignable to type 'never'
         (this._node as any)[property] = value;
         this._nodeValidationStore.updateProperty(property, value);
 

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -156,7 +156,7 @@ export class RoutePathStore {
 
         this.setOldRoutePath(this._routePath);
 
-        const validatePrimaryKey = () => {
+        const validatePrimaryKey = (routePath: IRoutePath) => {
             const isPrimaryKeyDuplicated = this._existingRoutePathPrimaryKeys.some(
                 rp =>
                     routePath.routeId === rp.routeId &&

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -59,6 +59,7 @@ class ValidationStore<ValidationObject, ValidationModel> {
         if (validatorResult) {
             this._invalidPropertiesMap[property] = validatorResult;
         }
+        if (!validatorResult?.isValid) return;
 
         if (!isDependentPropertiesValidationPrevented && customValidatorObject && customValidatorObject.dependentProperties) {
             customValidatorObject.dependentProperties.forEach(prop => this.validateProperty(prop, true));

--- a/src/stores/validationStore.ts
+++ b/src/stores/validationStore.ts
@@ -3,6 +3,7 @@ import FormValidator, { IValidationResult } from '~/validation/FormValidator';
 
 interface ICustomValidatorObject {
     validator: Function;
+    // TODO: use typings so that each element in string should be key in ValidationModel
     dependentProperties?: string[]; // List of properties that also need to be validated when the main property is validated
 }
 


### PR DESCRIPTION
Closes #1169 

* IViaName properties are now part of IRoutePathLink properties (they are extracted out before sending to backend - I know, they could be send to backend in the same object but it isn't worth refactoring)
    * code is a lot cleaner this way, IViaName validation is part of IRoutePathLink validations
* Had to change sidebar & map rendering order. Reason: map needs to be rendered before <Sidebar /> so that listeners get initialized before Views set map coordinates.
* Now if validating two properties at once, validation error will be only shown to the first field (prevents duplicate errors)