### PR TITLE
Fixed createLinkTool

### DIFF
--- a/src/components/map/layers/NetworkLayers.tsx
+++ b/src/components/map/layers/NetworkLayers.tsx
@@ -221,7 +221,11 @@ class NetworkLayers extends Component<INetworkLayersProps> {
             nodeId: properties.soltunnus,
             nodeType: properties.soltyyppi
         };
-        EventManager.trigger('networkNodeClick', clickParams);
+        // This way networkNodeClick event is triggered after mapClick event. Prevents bugs such as where deselecting tool after a click on map also triggers map click event.
+        // TODO: find a better way of achieving this.
+        setTimeout(() => {
+            EventManager.trigger('networkNodeClick', clickParams);
+        }, 0);
     };
 
     private onNetworkLinkClick = (clickEvent: any) => {
@@ -231,7 +235,11 @@ class NetworkLayers extends Component<INetworkLayersProps> {
             endNodeId: properties.lnkloppusolmu,
             transitType: properties.lnkverkko
         };
-        EventManager.trigger('networkLinkClick', clickParams);
+        // This way networkNodeClick event is triggered after mapClick event. Prevents bugs such as where deselecting tool after a click on map also triggers map click event.
+        // TODO: find a better way of achieving this.
+        setTimeout(() => {
+            EventManager.trigger('networkLinkClick', clickParams);
+        }, 0);
     };
 
     /**

--- a/src/components/map/layers/NetworkLayers.tsx
+++ b/src/components/map/layers/NetworkLayers.tsx
@@ -221,11 +221,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
             nodeId: properties.soltunnus,
             nodeType: properties.soltyyppi
         };
-        // This way networkNodeClick event is triggered after mapClick event. Prevents bugs such as where deselecting tool after a click on map also triggers map click event.
-        // TODO: find a better way of achieving this.
-        setTimeout(() => {
-            EventManager.trigger('networkNodeClick', clickParams);
-        }, 0);
+        EventManager.trigger('networkNodeClick', clickParams);
     };
 
     private onNetworkLinkClick = (clickEvent: any) => {
@@ -235,11 +231,7 @@ class NetworkLayers extends Component<INetworkLayersProps> {
             endNodeId: properties.lnkloppusolmu,
             transitType: properties.lnkverkko
         };
-        // This way networkNodeClick event is triggered after mapClick event. Prevents bugs such as where deselecting tool after a click on map also triggers map click event.
-        // TODO: find a better way of achieving this.
-        setTimeout(() => {
-            EventManager.trigger('networkLinkClick', clickParams);
-        }, 0);
+        EventManager.trigger('networkLinkClick', clickParams);
     };
 
     /**

--- a/src/components/map/tools/AddNetworkLinkTool.ts
+++ b/src/components/map/tools/AddNetworkLinkTool.ts
@@ -51,8 +51,6 @@ class AddNetworkLinkTool implements BaseTool {
         } else {
             this.endNodeId = nodeId;
             if (this.startNodeId === this.endNodeId) return;
-            // TODO?
-            // if (!this.isNewLinkValid(clickEvent, startNodeId, endNodeId)) return;
             this.redirectToNewLinkView();
         }
     };
@@ -63,26 +61,8 @@ class AddNetworkLinkTool implements BaseTool {
             .toTarget(':id', [this.startNodeId, this.endNodeId].join(','))
             .toLink();
         navigator.goTo(newLinkViewLink);
-
         ToolbarStore.selectTool(null);
     };
-
-    // TODO?
-    // If there is a link opened
-    // * the new link has to start from where current link ends
-    // * the new link has to end where the current link starts
-    // private isNewLinkValid =
-    // (clickEvent: CustomEvent, startNodeId: string, endNodeId: string) => {
-    //     const currentLink = LinkStore.link;
-    //     if (!currentLink) return true;
-    //     if (clickEvent.type === 'nodeClick') {
-    //         TODO: throw error if true
-    //         if (currentLink.endNode.id === startNodeId) return true;
-    //         if (currentLink.startNode.id === endNodeId) return true;
-    //         return false;
-    //     }
-    //     return true;
-    // }
 
     private resetTool = () => {
         this.startNodeId = null;

--- a/src/stores/toolbarStore.ts
+++ b/src/stores/toolbarStore.ts
@@ -24,7 +24,7 @@ const TOOL_LIST = [
 ];
 
 const TOOLS = {};
-TOOL_LIST.map((tool: BaseTool) => (TOOLS[tool.toolType] = tool));
+TOOL_LIST.forEach((tool: BaseTool) => (TOOLS[tool.toolType] = tool));
 
 export class ToolbarStore {
     @observable private _selectedTool: BaseTool | null;
@@ -50,8 +50,7 @@ export class ToolbarStore {
             this.selectDefaultTool();
             return;
         }
-        const foundTool = TOOLS[tool];
-        this._selectedTool = foundTool;
+        this._selectedTool = TOOLS[tool];
         if (!this._selectedTool) {
             throw new Error('Tried to select tool that was not found');
         }

--- a/src/stores/toolbarStore.ts
+++ b/src/stores/toolbarStore.ts
@@ -46,8 +46,17 @@ export class ToolbarStore {
         }
 
         // deselect current tool
-        if (tool === null || (this._selectedTool && this._selectedTool.toolType === tool)) {
-            this.selectDefaultTool();
+        if (
+            tool === null ||
+            tool === ToolbarTool.SelectNetworkEntity ||
+            (this._selectedTool && this._selectedTool.toolType === tool)
+        ) {
+            // Network click event also triggers mapClick event
+            // Prevents bugs where deselecting tool after a click on map also triggers map click event.
+            // TODO: find a better way of achieving this.
+            setTimeout(() => {
+                this.selectDefaultTool();
+            }, 0);
             return;
         }
         this._selectedTool = TOOLS[tool];


### PR DESCRIPTION
Steps to reproduce the bug:
1) select link tool
2) click a node on map
3) click some other node on map
-> opens up nodeView (or new linkView and click popup)

The reason for that bug is that when networkNodeClick even is triggered, the code execution goes to addNetworkLinkTool, redirects to new link, unselects tool, selects default tool (which is networkEntityTool) and only after all that, mapClick event gets triggered and networkEntityTool onClick is used

The solution was to make a setTimeout before SelectNetworkEntityTool (defaultTool) selection.