### PR TITLE
Refactored Loader component props, .loaderComponent wrapper class inside loader component

### DIFF
--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -16,7 +16,7 @@ import ApiClient from '~/util/ApiClient';
 import packageVersion from '../project/version.json';
 import { Button } from './controls/index';
 import * as s from './navigationBar.scss';
-import Loader, { LoaderSize } from './shared/loader/Loader';
+import Loader from './shared/loader/Loader';
 
 interface INavigationBarProps {
     alertStore?: AlertStore;
@@ -77,7 +77,7 @@ class NavigationBar extends Component<INavigationBarProps, INavigationBarState> 
                         <>
                             {isSyncLoading ? (
                                 <div className={s.syncTextWrapper}>
-                                    <Loader size={LoaderSize.TINY} />
+                                    <Loader size='tiny' />
                                     <div className={s.syncText}>
                                         Synkronoidaan sisäistä JORE-tietokantaa...
                                     </div>

--- a/src/components/controls/Dropdown.tsx
+++ b/src/components/controls/Dropdown.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Select from 'react-select';
 import { InputActionMeta } from 'react-select/src/types';
 import { IValidationResult } from '~/validation/FormValidator';
-import Loader, { LoaderSize } from '../shared/loader/Loader';
+import Loader from '../shared/loader/Loader';
 import * as s from './dropdown.scss';
 
 export interface IDropdownItem {
@@ -134,9 +134,7 @@ class Dropdown extends React.Component<IDropdownProps, IDropdownState> {
                         </div>
                     )}
                     {props.isLoading ? (
-                        <div className={s.loaderContainer}>
-                            <Loader size={LoaderSize.SMALL} />
-                        </div>
+                        <Loader size='small' />
                     ) : props.disabled ? (
                         <div className={s.disableEditing}>
                             {Boolean(selectedItem) ? selectedItem!.label : EMPTY_VALUE_LABEL}

--- a/src/components/controls/dropdown.scss
+++ b/src/components/controls/dropdown.scss
@@ -13,9 +13,4 @@
         pointer-events: none;
         cursor: default;
     }
-
-    .loaderContainer {
-        display: flex;
-        justify-content: center;
-    }
 }

--- a/src/components/overlays/Alert.tsx
+++ b/src/components/overlays/Alert.tsx
@@ -5,7 +5,7 @@ import { FaCheckCircle } from 'react-icons/fa';
 import { IoMdInformationCircle } from 'react-icons/io';
 import { AlertStore, AlertType } from '~/stores/alertStore';
 import { Button } from '../controls';
-import Loader, { LoaderSize } from '../shared/loader/Loader';
+import Loader from '../shared/loader/Loader';
 import Modal from './Modal';
 import * as s from './alert.scss';
 
@@ -33,11 +33,7 @@ class Alert extends React.Component<IAlertProps> {
                     {alertStore.type === AlertType.Info && (
                         <IoMdInformationCircle className={classnames(s.icon, s.info)} />
                     )}
-                    {alertStore.type === AlertType.Loader && (
-                        <div className={s.icon}>
-                            <Loader size={LoaderSize.SMALL} />
-                        </div>
-                    )}
+                    {alertStore.type === AlertType.Loader && <Loader size='small' />}
                     {alertStore.message}
                     {alertStore.isCancelButtonVisible && (
                         <Button className={s.closeAlertButton} onClick={this.closeAlert}>

--- a/src/components/shared/loader/Loader.tsx
+++ b/src/components/shared/loader/Loader.tsx
@@ -1,20 +1,25 @@
+import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import React from 'react';
 import * as s from './loader.scss';
 
-// TODO: refactor as type instead
-export enum LoaderSize {
-    TINY = 'tiny',
-    SMALL = 'small',
-    MEDIUM = 'medium'
-}
+type loaderSize = 'tiny' | 'small' | 'medium';
 
 interface ILoaderProps {
-    size?: LoaderSize;
+    size?: loaderSize;
+    hasNoMargin?: boolean;
 }
 
 const Loader = observer((props: ILoaderProps) => (
-    <div id={s.loader} className={s[props.size! || LoaderSize.MEDIUM]} />
+    <div
+        className={classnames(
+            s.loaderContainer,
+            s[props.size! || 'medium'],
+            props.hasNoMargin ? s.hasNoMargin : undefined
+        )}
+    >
+        <div className={classnames(s.loader, s[props.size! || 'medium'])} />
+    </div>
 ));
 
 export default Loader;

--- a/src/components/shared/loader/loader.scss
+++ b/src/components/shared/loader/loader.scss
@@ -1,31 +1,49 @@
-div#loader {
+.loaderContainer {
+    height: 100%;
     &.tiny {
-        width: 20px;
-        height: 20px;
+        margin: 10px;
     }
     &.small {
-        width: 34px;
-        height: 34px;
+        margin: 25px;
     }
     &.medium {
-        width: 68px;
-        height: 68px;
+        margin: 40px;
     }
-    position: relative;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIgAAACICAMAAAALZFNgAAAAh1BMVEUAAAD////+9/zxl9D2t9/3w+T////zotX5y+j////////////////////61u3////////0rdr62u7////zqNf96/byndL////////////////////////////////////////////////74/L////////////////////////////////wks2G9zQVAAAALHRSTlMAs7j84NcO8dGUN0yAGcoFJ+fHrOu+9R+ncGmkm4V6YyJCXcMxUaCLdAouFScDv6EAAAX6SURBVHjaxJnnkuIwEISnJTninDAYbHLY8/s/39VSF5AslmSb7+eGcjPT3RJArxKu3P28XjpVmQJpWTnLer53VyGNSBhNTg5u4Jwm0Shq/ImX4ps8MEScWZzztuWcW1ksjCDHN6k38WlQphvnosEWFm+1cEvYFzXOZkoDYU4cAMwWvL0DFzYD4ExM6p/VLP1WkbUPkn1rSWcr6pfdEkASt08RJwCWO+qPryPAjKJ9msJgwPGrL4cuASZ4+xJcMGDZh2/NuSTjRSnzt227rgCbt2/BDaBa0zv88oDEat/GSgDvF72MW4KJthcEQ+nSa4QzIOBtT/AAmIX0Ar5zZxxFLOxgmzMGMJZvA1vExZ2hOP4LFVYiv+kOnhkJgwaWGBm/6ZQc5e7ptNxeCxfBRcTBayZu5JtnorPpR+6k8Q4XMYHgt9fzZHo2gHGjtwMAcBrX1LaO2zgAEMStFgPY0BPMAaFvBAbAW5s/VuDaA8AMrjUKMKeHmYHFOnfaTH+2628MzC50E2WYPaEj00zjW0Yd0YNENcB0nZw9rGQOZmnDh5P/VP5P0BaAxR7bzkY3D2sLeFN6kqkHbC3NTB5x7ATIdGZfvFTQuwVg6JRM7v6nJi/FFmhCeomwAbaFJjtfd/ZawtD4fBHRy0QLTQYNlP6P+h0EmrXUZ3qDc61ZTwAn/DG4OVdDC+zpTfbdyxXPfwqx2wkuT5C69DZuioR3QuzevI+VEB0d1Yp64KvsKBEof5EeD0FHx8GnXpgeOkoCeLdOfsb706Hid5Rwpr8TmJW6GBuVT73hV7DV5VSm9ohJ1NymK+qRaaqmOMFc82dAIfcY4FKvuEAsVzYwJZWlIrdg2FPP7MEKZejLTr5Up25RU+/U2Kp+Vc+cI4SidXGm3jkvlLkLHElipwzEAiIagAiwlJHsFIcIZTENDUKjLEfILlkpAxFYhDQI4QJCGclKOnUN5bcuDYSrvGbj+hQ2UxRypXo0GB5suUtS8+qemigVMqXBmCplklzdXx3E8kBONCAneSQxnCuNXHaITwPiK4/7P/+NLNFATYNSy9Gw/73LWSCTFUY0KJE8kgyLf6NSdzYsqif/WmECW3XxsKgptf880ZO6jgMmDYwJcKnHvUvppp2fDo762tPwYp1cvluvaXDW8vuFHFHHIpzBpMExwXjHJCcIKUtHGoEjMskOp0uWLKnNGhqBRuo0Cw5RKDs4gUsj4CKRkxrSSvbqcBZRTSK7dUWuZOACBxqFAwopqi7tpW3F8GgUPMSSM/c0h5D829AoNMpj51QjVhI9Amp7xahpiUxZ1hgo1sywVGpki4hGIcJWKZIKXMqRT6PgS63BUVEJPn6NqEXCUVKqCDnTKJwVISkB7RUAjYT63A8K4dJh87nVwLpOTfo5s8KQviP4XHzBrKuPw6vPFRqQW/++mIbzuYoHwIzfzdzNjoIwFAXgdsjIIJqauBBQJtjgYGTe//kmcWN62vIz0B6/tSuNSnvPuWmSpM8Rbs370zN98x4DTBXvwch04z0qmra0h2fQ0I4TQJEOWFqaMt6R03SnHcJBTruWAAfaRY3pqFhXV2BHu8wDOe16E+xZF77gQrsCB/o1FPiNOhRAJ9aYBGSswRHKWaM0cNyQhouoZI1bUUMaQKOaNZJHLSmkgLrx2MZdrO4uLQ9OkMVSc6I9ttO0sBO8bHHYyVJx4l+W82ZyIK4XK+l/pO1KiQjadvFDk4dC2op+Xoy0XSVG6rAlBGtdSkLU2CVT8cPXLsU+ehzd7TF+CvtwB/Tbfwb03fLYlQUPvazEUc4rcZTSp4pba/GZV7BZXPTxK6NWn/yqNctgnfaVwXQnh+lg9TglhHrV48ZcYxQGxxVt0ArlZNk+bKn0OfyZoFRBarbY0xxTbKMUj9Ox92TXL65iQxnS40sOOV+jldNTOaDaiOWaaXX9RHrVjRDxFhgk0qN7iPW0NZR4p300sNIhzpKLT4ncSy5Cr/3Ary+s/VjZSV9gEYr3B+3iX4QSbDUM/MTDapiA1OH2BstyzPVB3Wt9ULdsfdAfATeCPkBuRCEAAAAASUVORK5CYII=);
-    -webkit-animation: spin 4s linear infinite;
-    animation: spin 4s linear infinite;
-    background-size: cover;
-}
-@-webkit-keyframes spin {
-    to {
-        -webkit-transform: rotate(1turn);
-        transform: rotate(1turn);
+    &.hasNoMargin {
+        margin: 0px;
     }
-}
-@keyframes spin {
-    to {
-        -webkit-transform: rotate(1turn);
-        transform: rotate(1turn);
+
+    .loader {
+        margin: 30px auto;
+
+        &.tiny {
+            width: 20px;
+            height: 20px;
+        }
+        &.small {
+            width: 34px;
+            height: 34px;
+        }
+        &.medium {
+            width: 68px;
+            height: 68px;
+        }
+        position: relative;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIgAAACICAMAAAALZFNgAAAAh1BMVEUAAAD////+9/zxl9D2t9/3w+T////zotX5y+j////////////////////61u3////////0rdr62u7////zqNf96/byndL////////////////////////////////////////////////74/L////////////////////////////////wks2G9zQVAAAALHRSTlMAs7j84NcO8dGUN0yAGcoFJ+fHrOu+9R+ncGmkm4V6YyJCXcMxUaCLdAouFScDv6EAAAX6SURBVHjaxJnnkuIwEISnJTninDAYbHLY8/s/39VSF5AslmSb7+eGcjPT3RJArxKu3P28XjpVmQJpWTnLer53VyGNSBhNTg5u4Jwm0Shq/ImX4ps8MEScWZzztuWcW1ksjCDHN6k38WlQphvnosEWFm+1cEvYFzXOZkoDYU4cAMwWvL0DFzYD4ExM6p/VLP1WkbUPkn1rSWcr6pfdEkASt08RJwCWO+qPryPAjKJ9msJgwPGrL4cuASZ4+xJcMGDZh2/NuSTjRSnzt227rgCbt2/BDaBa0zv88oDEat/GSgDvF72MW4KJthcEQ+nSa4QzIOBtT/AAmIX0Ar5zZxxFLOxgmzMGMJZvA1vExZ2hOP4LFVYiv+kOnhkJgwaWGBm/6ZQc5e7ptNxeCxfBRcTBayZu5JtnorPpR+6k8Q4XMYHgt9fzZHo2gHGjtwMAcBrX1LaO2zgAEMStFgPY0BPMAaFvBAbAW5s/VuDaA8AMrjUKMKeHmYHFOnfaTH+2628MzC50E2WYPaEj00zjW0Yd0YNENcB0nZw9rGQOZmnDh5P/VP5P0BaAxR7bzkY3D2sLeFN6kqkHbC3NTB5x7ATIdGZfvFTQuwVg6JRM7v6nJi/FFmhCeomwAbaFJjtfd/ZawtD4fBHRy0QLTQYNlP6P+h0EmrXUZ3qDc61ZTwAn/DG4OVdDC+zpTfbdyxXPfwqx2wkuT5C69DZuioR3QuzevI+VEB0d1Yp64KvsKBEof5EeD0FHx8GnXpgeOkoCeLdOfsb706Hid5Rwpr8TmJW6GBuVT73hV7DV5VSm9ohJ1NymK+qRaaqmOMFc82dAIfcY4FKvuEAsVzYwJZWlIrdg2FPP7MEKZejLTr5Up25RU+/U2Kp+Vc+cI4SidXGm3jkvlLkLHElipwzEAiIagAiwlJHsFIcIZTENDUKjLEfILlkpAxFYhDQI4QJCGclKOnUN5bcuDYSrvGbj+hQ2UxRypXo0GB5suUtS8+qemigVMqXBmCplklzdXx3E8kBONCAneSQxnCuNXHaITwPiK4/7P/+NLNFATYNSy9Gw/73LWSCTFUY0KJE8kgyLf6NSdzYsqif/WmECW3XxsKgptf880ZO6jgMmDYwJcKnHvUvppp2fDo762tPwYp1cvluvaXDW8vuFHFHHIpzBpMExwXjHJCcIKUtHGoEjMskOp0uWLKnNGhqBRuo0Cw5RKDs4gUsj4CKRkxrSSvbqcBZRTSK7dUWuZOACBxqFAwopqi7tpW3F8GgUPMSSM/c0h5D829AoNMpj51QjVhI9Amp7xahpiUxZ1hgo1sywVGpki4hGIcJWKZIKXMqRT6PgS63BUVEJPn6NqEXCUVKqCDnTKJwVISkB7RUAjYT63A8K4dJh87nVwLpOTfo5s8KQviP4XHzBrKuPw6vPFRqQW/++mIbzuYoHwIzfzdzNjoIwFAXgdsjIIJqauBBQJtjgYGTe//kmcWN62vIz0B6/tSuNSnvPuWmSpM8Rbs370zN98x4DTBXvwch04z0qmra0h2fQ0I4TQJEOWFqaMt6R03SnHcJBTruWAAfaRY3pqFhXV2BHu8wDOe16E+xZF77gQrsCB/o1FPiNOhRAJ9aYBGSswRHKWaM0cNyQhouoZI1bUUMaQKOaNZJHLSmkgLrx2MZdrO4uLQ9OkMVSc6I9ttO0sBO8bHHYyVJx4l+W82ZyIK4XK+l/pO1KiQjadvFDk4dC2op+Xoy0XSVG6rAlBGtdSkLU2CVT8cPXLsU+ehzd7TF+CvtwB/Tbfwb03fLYlQUPvazEUc4rcZTSp4pba/GZV7BZXPTxK6NWn/yqNctgnfaVwXQnh+lg9TglhHrV48ZcYxQGxxVt0ArlZNk+bKn0OfyZoFRBarbY0xxTbKMUj9Ox92TXL65iQxnS40sOOV+jldNTOaDaiOWaaXX9RHrVjRDxFhgk0qN7iPW0NZR4p300sNIhzpKLT4ncSy5Cr/3Ary+s/VjZSV9gEYr3B+3iX4QSbDUM/MTDapiA1OH2BstyzPVB3Wt9ULdsfdAfATeCPkBuRCEAAAAASUVORK5CYII=);
+        -webkit-animation: spin 4s linear infinite;
+        animation: spin 4s linear infinite;
+        background-size: cover;
+    }
+    @-webkit-keyframes spin {
+        to {
+            -webkit-transform: rotate(1turn);
+            transform: rotate(1turn);
+        }
+    }
+    @keyframes spin {
+        to {
+            -webkit-transform: rotate(1turn);
+            transform: rotate(1turn);
+        }
     }
 }

--- a/src/components/shared/searchView/SearchInput.tsx
+++ b/src/components/shared/searchView/SearchInput.tsx
@@ -2,7 +2,7 @@ import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { SearchResultStore } from '~/stores/searchResultStore';
 import { SearchStore } from '~/stores/searchStore';
-import Loader, { LoaderSize } from '../loader/Loader';
+import Loader from '../loader/Loader';
 import * as s from './searchInput.scss';
 
 interface ISearchInputProps {
@@ -30,7 +30,7 @@ class SearchInput extends React.Component<ISearchInputProps> {
                     />
                     {this.props.searchResultStore!.isSearching && (
                         <div className={s.loader}>
-                            <Loader size={LoaderSize.TINY} />
+                            <Loader size='tiny' hasNoMargin={true} />
                         </div>
                     )}
                 </div>

--- a/src/components/shared/searchView/SearchResults.tsx
+++ b/src/components/shared/searchView/SearchResults.tsx
@@ -131,11 +131,7 @@ class SearchResults extends React.Component<ISearchResultsProps, ISearchResultsS
 
     render() {
         if (this.state.isLoading) {
-            return (
-                <div className={s.loaderContainer}>
-                    <Loader />
-                </div>
-            );
+            return <Loader />;
         }
         const isRouteListView = matchPath(Navigator.getPathName(), subSites.routes);
         const filteredItems = this.getFilteredItems();

--- a/src/components/shared/searchView/searchInput.scss
+++ b/src/components/shared/searchView/searchInput.scss
@@ -2,12 +2,12 @@
     .inputContainer {
         padding: 10px;
         position: relative;
+    }
 
-        .loader {
-            position: absolute;
-            right: 25px;
-            top: 20px;
-        }
+    .loader {
+        position: absolute;
+        right: 25px;
+        top: -8px;
     }
 
     .searchResultsContainer {

--- a/src/components/shared/searchView/searchResults.scss
+++ b/src/components/shared/searchView/searchResults.scss
@@ -19,7 +19,3 @@
         margin-top: 20px;
     }
 }
-.loaderContainer {
-    margin: 30px auto;
-    height: 100%;
-}

--- a/src/components/sidebar/lineView/LineHeaderTable.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTable.tsx
@@ -4,7 +4,7 @@ import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { Button } from '~/components/controls';
 import InputContainer from '~/components/controls/InputContainer';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import ButtonType from '~/enums/buttonType';
 import LineHeaderFactory from '~/factories/lineHeaderFactory';
 import ILineHeader from '~/models/ILineHeader';
@@ -151,11 +151,7 @@ class LineHeaderTable extends React.Component<ILineHeaderListProps, ILineHeaderS
 
     render() {
         if (this.state.isLoading) {
-            return (
-                <div className={classnames(s.lineHeaderTableView, s.loaderContainer)}>
-                    <Loader size={LoaderSize.TINY} />
-                </div>
-            );
+            return <Loader size='small' />;
         }
 
         const lineHeaderMassEditStore = this.props.lineHeaderMassEditStore;

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -1,9 +1,8 @@
-import classnames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { match } from 'react-router';
 import { ContentItem, ContentList, Tab, Tabs, TabList } from '~/components/shared/Tabs';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import LineFactory from '~/factories/lineFactory';
 import navigator from '~/routing/navigator';
 import routeBuilder from '~/routing/routeBuilder';
@@ -136,8 +135,8 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
         const lineHeaderMassEditStore = this.props.lineHeaderMassEditStore;
         if (this.state.isLoading) {
             return (
-                <div className={classnames(s.lineView, s.loaderContainer)}>
-                    <Loader size={LoaderSize.MEDIUM} />
+                <div className={s.lineView}>
+                    <Loader size='medium' />
                 </div>
             );
         }

--- a/src/components/sidebar/lineView/lineHeaderTable.scss
+++ b/src/components/sidebar/lineView/lineHeaderTable.scss
@@ -8,10 +8,6 @@ $cellPadding: 5px 2px 5px 2px; // same as in lineHeaderTableRows.scss
     width: 100%;
     padding-top: 20px;
 
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
-
     .lineHeaderTable {
         width: 100%;
         border-collapse: collapse;

--- a/src/components/sidebar/lineView/lineView.scss
+++ b/src/components/sidebar/lineView/lineView.scss
@@ -8,8 +8,4 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
 }

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import L from 'leaflet';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
@@ -216,7 +215,7 @@ class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
         const link = this.props.linkStore!.link;
         if (this.state.isLoading) {
             return (
-                <div className={classnames(s.linkView, s.loaderContainer)}>
+                <div className={s.linkView}>
                     <Loader />
                 </div>
             );

--- a/src/components/sidebar/linkView/linkView.scss
+++ b/src/components/sidebar/linkView/linkView.scss
@@ -5,7 +5,7 @@
 .linkView {
     display: flex;
     flex-direction: column;
-    width: 500px;
+    width: $sidebarWide;
 
     .content {
         padding: 20px;
@@ -69,9 +69,5 @@
         > div:last-of-type {
             border-right: none;
         }
-    }
-
-    &.loaderContainer > div {
-        margin: 30px auto;
     }
 }

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import * as L from 'leaflet';
 import _ from 'lodash';
 import { inject, observer } from 'mobx-react';
@@ -393,11 +392,8 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
         const nodeStore = this.props.nodeStore!;
         const node = nodeStore.node;
         if (this.state.isLoading) {
-            return (
-                <div className={classnames(s.nodeView, s.loaderContainer)}>
-                    <Loader />
-                </div>
-            );
+
+            return <div className={s.nodeView}><Loader /></div>
         }
         // TODO: show some indicator to user of an empty page
         if (!node) return null;

--- a/src/components/sidebar/nodeView/StopView.tsx
+++ b/src/components/sidebar/nodeView/StopView.tsx
@@ -2,7 +2,7 @@ import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { IDropdownItem } from '~/components/controls/Dropdown';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import TransitType from '~/enums/transitType';
 import { INode, IStop } from '~/models';
 import StopAreaService, { IStopAreaItem } from '~/services/stopAreaService';
@@ -10,7 +10,6 @@ import StopService, { IStopSectionItem } from '~/services/stopService';
 import { CodeListStore } from '~/stores/codeListStore';
 import { NodeStore } from '~/stores/nodeStore';
 import StopForm from './StopForm';
-import * as s from './stopView.scss';
 
 interface IStopViewProps {
     node: INode;
@@ -103,11 +102,7 @@ class StopView extends React.Component<IStopViewProps, IStopViewState> {
         const { node, isNewStop, onNodePropertyChange, toggleTransitType } = this.props;
 
         if (this.state.isLoading) {
-            return (
-                <div className={s.loaderContainer}>
-                    <Loader size={LoaderSize.SMALL} />
-                </div>
-            );
+            return <Loader size='small' />;
         }
 
         return (

--- a/src/components/sidebar/nodeView/nodeView.scss
+++ b/src/components/sidebar/nodeView/nodeView.scss
@@ -5,15 +5,11 @@
 .nodeView {
     display: flex;
     flex-direction: column;
-    width: 500px;
+    width: $sidebarWide;
 
     .content {
         padding: 20px;
         overflow-y: auto;
         flex-grow: 1;
-    }
-
-    &.loaderContainer > div {
-        margin: 30px auto;
     }
 }

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { match } from 'react-router';
@@ -232,7 +231,7 @@ class StopAreaView extends React.Component<IStopAreaViewProps, IStopAreaViewStat
         const invalidPropertiesMap = stopAreaStore.invalidPropertiesMap;
         if (this.state.isLoading) {
             return (
-                <div className={classnames(s.stopAreaView, s.loaderContainer)}>
+                <div className={s.stopAreaView}>
                     <Loader />
                 </div>
             );

--- a/src/components/sidebar/nodeView/stopAreaView/StopTable.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopTable.tsx
@@ -2,7 +2,7 @@ import classnames from 'classnames';
 import * as L from 'leaflet';
 import { inject, observer } from 'mobx-react';
 import React, { Component } from 'react';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import { IStopArea } from '~/models';
 import StopService, { IStopItem } from '~/services/stopService';
 import { MapStore } from '~/stores/mapStore';
@@ -67,11 +67,7 @@ export default class StopTable extends Component<IStopTableProps, IStopTableStat
 
     render() {
         if (this.state.isLoading) {
-            return (
-                <div className={classnames(s.stopTableView, s.loaderContainer)}>
-                    <Loader size={LoaderSize.SMALL} />
-                </div>
-            );
+            return <Loader size='small' />;
         }
         const stopItems = this.props.stopAreaStore!.stopItems;
         return (

--- a/src/components/sidebar/nodeView/stopAreaView/stopAreaView.scss
+++ b/src/components/sidebar/nodeView/stopAreaView/stopAreaView.scss
@@ -8,10 +8,6 @@
     display: flex;
     flex-direction: column;
 
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
-
     .content {
         padding: 20px;
         overflow-y: auto;

--- a/src/components/sidebar/nodeView/stopAreaView/stopTable.scss
+++ b/src/components/sidebar/nodeView/stopAreaView/stopTable.scss
@@ -2,12 +2,6 @@
 @import '../../../shared/styles/form';
 @import '../../../shared/styles/flexbox';
 
-.loaderContainer {
-    display: flex;
-    justify-content: center;
-    margin: 30px auto;
-}
-
 .stopTableView {
     width: 100%;
 

--- a/src/components/sidebar/nodeView/stopView.scss
+++ b/src/components/sidebar/nodeView/stopView.scss
@@ -1,3 +1,0 @@
-.loaderContainer > div {
-    margin: 30px auto;
-}

--- a/src/components/sidebar/routeListView/RouteList.tsx
+++ b/src/components/sidebar/routeListView/RouteList.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import L from 'leaflet';
 import { autorun } from 'mobx';
 import { inject, observer } from 'mobx-react';
@@ -127,11 +126,7 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
 
     render() {
         if (this.state.isLoading) {
-            return (
-                <div className={classnames(s.routeListView, s.loaderContainer)}>
-                    <Loader />
-                </div>
-            );
+            return <Loader />;
         }
         return (
             <div className={s.routeListView}>

--- a/src/components/sidebar/routeListView/routeList.scss
+++ b/src/components/sidebar/routeListView/routeList.scss
@@ -35,8 +35,4 @@
         padding-top: 10px;
         display: flex;
     }
-
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
 }

--- a/src/components/sidebar/routePathView/RoutePathCopySegmentView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathCopySegmentView.tsx
@@ -2,7 +2,7 @@ import { inject, observer } from 'mobx-react';
 import Moment from 'moment';
 import React from 'react';
 import { FiCopy, FiExternalLink } from 'react-icons/fi';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import { IRoutePathLink } from '~/models';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
@@ -199,11 +199,7 @@ class RoutePathCopySegmentView extends React.Component<IRoutePathCopySegmentView
                 {
                     {
                         hasError: this.renderErrorMessage(),
-                        isLoading: (
-                            <div className={s.loaderContainer}>
-                                <Loader size={LoaderSize.SMALL} />
-                            </div>
-                        ),
+                        isLoading: <Loader size='small' />,
                         showResults: this.renderResults()
                     }[state]
                 }

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import L from 'leaflet';
 import _ from 'lodash';
 import { inject, observer } from 'mobx-react';
@@ -6,7 +5,7 @@ import Moment from 'moment';
 import React from 'react';
 import { match } from 'react-router';
 import Button from '~/components/controls/Button';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import ButtonType from '~/enums/buttonType';
 import ToolbarTool from '~/enums/toolbarTool';
 import RoutePathFactory from '~/factories/routePathFactory';
@@ -289,9 +288,7 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
         const routePathStore = this.props.routePathStore;
         if (this.state.isLoading) {
             return (
-                <div className={classnames(s.routePathView, s.loaderContainer)}>
-                    <Loader size={LoaderSize.MEDIUM} />
-                </div>
+                <div className={s.routePathView}><Loader size='medium' /></div>
             );
         }
         if (!routePathStore!.routePath) return null;

--- a/src/components/sidebar/routePathView/routePathCopySegmentView.scss
+++ b/src/components/sidebar/routePathView/routePathCopySegmentView.scss
@@ -53,11 +53,6 @@
             background-color: $backgroundlightGrey;
         }
     }
-
-    .loaderContainer {
-        margin: 10px auto;
-        height: 100%;
-    }
 }
 
 .topic {

--- a/src/components/sidebar/routePathView/routePathView.scss
+++ b/src/components/sidebar/routePathView/routePathView.scss
@@ -30,8 +30,4 @@
         margin-right: 10px;
         font-weight: bold;
     }
-
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
 }

--- a/src/components/sidebar/routeView/RouteView.tsx
+++ b/src/components/sidebar/routeView/RouteView.tsx
@@ -1,4 +1,3 @@
-import classnames from 'classnames';
 import { reaction, IReactionDisposer } from 'mobx';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
@@ -7,7 +6,7 @@ import Button from '~/components/controls/Button';
 import SavePrompt, { ISaveModel } from '~/components/overlays/SavePrompt';
 import { ContentItem, ContentList, Tab, Tabs, TabList } from '~/components/shared/Tabs';
 import ViewFormBase from '~/components/shared/inheritedComponents/ViewFormBase';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import ButtonType from '~/enums/buttonType';
 import RouteFactory from '~/factories/routeFactory';
 import { IRoute } from '~/models';
@@ -211,8 +210,8 @@ class RouteView extends ViewFormBase<IRouteViewProps, IRouteViewState> {
         const routeStore = this.props.routeStore;
         if (this.state.isLoading) {
             return (
-                <div className={classnames(s.routeView, s.loaderContainer)}>
-                    <Loader size={LoaderSize.MEDIUM} />
+                <div className={s.routeView}>
+                    <Loader size='medium' />
                 </div>
             );
         }

--- a/src/components/sidebar/routeView/routeView.scss
+++ b/src/components/sidebar/routeView/routeView.scss
@@ -9,10 +9,6 @@
     display: flex;
     flex-direction: column;
 
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
-
     .content {
         overflow-y: auto;
         flex-grow: 1;

--- a/src/components/sidebar/splitLinkView/RoutePathSelector.tsx
+++ b/src/components/sidebar/splitLinkView/RoutePathSelector.tsx
@@ -1,7 +1,7 @@
 import Moment from 'moment';
 import * as React from 'react';
 import { Checkbox } from '~/components/controls';
-import Loader, { LoaderSize } from '~/components/shared/loader/Loader';
+import Loader from '~/components/shared/loader/Loader';
 import { IRoutePath } from '~/models';
 import * as s from './routePathSelector.scss';
 
@@ -34,13 +34,7 @@ const RoutePathSelector = (props: IRoutePathSelectorProps) => {
     );
 
     if (props.isLoading) {
-        return (
-            <div className={s.routePathSelectorView}>
-                <div className={s.loader}>
-                    <Loader size={LoaderSize.SMALL} />
-                </div>
-            </div>
-        );
+        return <Loader size='small' />;
     }
 
     return (

--- a/src/components/sidebar/splitLinkView/SplitLinkView.tsx
+++ b/src/components/sidebar/splitLinkView/SplitLinkView.tsx
@@ -207,11 +207,7 @@ class SplitLinkView extends React.Component<ISplitLinkViewProps, ISplitLinkViewS
 
         const link = this.props.linkStore!.link;
         if (this.state.isLoading) {
-            return (
-                <div className={classnames(s.splitLinkView, s.loaderContainer)}>
-                    <Loader />
-                </div>
-            );
+            return <Loader />;
         }
         if (!node || !link) return null;
         return (

--- a/src/components/sidebar/splitLinkView/routePathSelector.scss
+++ b/src/components/sidebar/splitLinkView/routePathSelector.scss
@@ -23,12 +23,6 @@
         }
     }
 
-    .loader {
-        > * {
-            margin: 10px auto;
-        }
-    }
-
     .checkboxContent {
         display: flex;
 

--- a/src/components/sidebar/splitLinkView/splitLinkView.scss
+++ b/src/components/sidebar/splitLinkView/splitLinkView.scss
@@ -37,8 +37,4 @@
             overflow-y: auto;
         }
     }
-
-    &.loaderContainer > div {
-        margin: 30px auto;
-    }
 }


### PR DESCRIPTION
Closes #1125 

Straightforward refactor. Now when using <Loader /> component you have to write less boilerplate.