### PR TITLE
1143 remove text container use input container instead

### DIFF
--- a/src/components/controls/Dropdown.tsx
+++ b/src/components/controls/Dropdown.tsx
@@ -21,7 +21,7 @@ interface IDropdownProps {
     emptyItem?: IDropdownItem;
     onChange?: (value: any) => void;
     validationResult?: IValidationResult;
-    darkerInputLabel?: boolean;
+    isInputLabelDarker?: boolean;
     isBackgroundGrey?: boolean;
     isAnyInputValueAllowed?: boolean; // Can user give any input as dropdown field value
     isNoOptionsMessageHidden?: boolean;
@@ -129,7 +129,9 @@ class Dropdown extends React.Component<IDropdownProps, IDropdownState> {
             <div className={s.formItem}>
                 <div className={s.dropdownView}>
                     {props.label && (
-                        <div className={props.darkerInputLabel ? s.darkerInputLabel : s.inputLabel}>
+                        <div
+                            className={props.isInputLabelDarker ? s.darkerInputLabel : s.inputLabel}
+                        >
                             {props.label}
                         </div>
                     )}

--- a/src/components/controls/InputContainer.tsx
+++ b/src/components/controls/InputContainer.tsx
@@ -23,7 +23,7 @@ interface IInputProps {
     isInputColorRed?: boolean;
     isClearButtonVisibleOnDates?: boolean;
     isTimeIncluded?: boolean;
-    darkerInputLabel?: boolean; // TODO: rename as isInputLabelDarker
+    isInputLabelDarker?: boolean;
 }
 
 const renderEditableContent = (props: IInputProps) => {
@@ -100,7 +100,7 @@ const InputContainer = observer((props: IInputProps) => {
     return (
         <div className={classnames(s.formItem, s.inputContainer, props.className)}>
             {props.label && (
-                <div className={props.darkerInputLabel ? s.darkerInputLabel : s.inputLabel}>
+                <div className={props.isInputLabelDarker ? s.darkerInputLabel : s.inputLabel}>
                     {props.label}
                 </div>
             )}

--- a/src/components/controls/InputContainer.tsx
+++ b/src/components/controls/InputContainer.tsx
@@ -22,6 +22,7 @@ interface IInputProps {
     capitalizeInput?: boolean;
     isInputColorRed?: boolean;
     isClearButtonVisibleOnDates?: boolean;
+    isTimeIncluded?: boolean;
     darkerInputLabel?: boolean; // TODO: rename as isInputLabelDarker
 }
 
@@ -88,7 +89,7 @@ const renderUneditableContent = (props: IInputProps) => (
         )}
     >
         {props.value instanceof Date
-            ? Moment(props.value!).format('DD.MM.YYYY')
+            ? Moment(props.value!).format(props.isTimeIncluded ? 'DD.MM.YYYY HH:mm' : 'DD.MM.YYYY')
             : props.value
             ? props.value
             : '-'}

--- a/src/components/controls/InputContainer.tsx
+++ b/src/components/controls/InputContainer.tsx
@@ -1,10 +1,10 @@
 import classnames from 'classnames';
 import { observer } from 'mobx-react';
-import Moment from 'moment';
 import React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
 import { IValidationResult } from '~/validation/FormValidator';
 import DatePicker from './DatePicker';
+import TextContainer from './TextContainer';
 import * as s from './inputContainer.scss';
 
 type inputType = 'text' | 'number' | 'date';
@@ -80,23 +80,27 @@ const renderValidatorResult = (validationResult?: IValidationResult) => {
     return <div className={s.errorMessage}>{validationResult.errorMessage}</div>;
 };
 
-const renderUneditableContent = (props: IInputProps) => (
-    <div
-        className={classnames(
-            s.inputField,
-            props.disabled ? s.staticHeight : null,
-            props.isInputColorRed ? s.redInputText : null
-        )}
-    >
-        {props.value instanceof Date
-            ? Moment(props.value!).format(props.isTimeIncluded ? 'DD.MM.YYYY HH:mm' : 'DD.MM.YYYY')
-            : props.value
-            ? props.value
-            : '-'}
-    </div>
-);
+const renderUneditableContent = (props: IInputProps) => {
+    return (
+        <TextContainer
+            label={props.label}
+            value={props.value}
+            isTimeIncluded={props.isTimeIncluded}
+            isInputLabelDarker={props.isInputLabelDarker}
+            isInputColorRed={props.isInputColorRed}
+        />
+    );
+};
 
 const InputContainer = observer((props: IInputProps) => {
+    if (props.disabled) {
+        return (
+            <>
+                {renderUneditableContent(props)}
+                {renderValidatorResult(props.validationResult)}
+            </>
+        );
+    }
     return (
         <div className={classnames(s.formItem, s.inputContainer, props.className)}>
             {props.label && (
@@ -104,7 +108,7 @@ const InputContainer = observer((props: IInputProps) => {
                     {props.label}
                 </div>
             )}
-            {props.disabled ? renderUneditableContent(props) : renderEditableContent(props)}
+            {renderEditableContent(props)}
             {renderValidatorResult(props.validationResult)}
         </div>
     );

--- a/src/components/controls/TextContainer.tsx
+++ b/src/components/controls/TextContainer.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { observer } from 'mobx-react';
 import Moment from 'moment';
 import React from 'react';
@@ -8,6 +9,7 @@ interface ITextContainerProps {
     value?: string | number | null | Date;
     isTimeIncluded?: boolean;
     isInputLabelDarker?: boolean;
+    isInputColorRed?: boolean;
 }
 
 const TextContainer = observer((props: ITextContainerProps) => (
@@ -15,7 +17,13 @@ const TextContainer = observer((props: ITextContainerProps) => (
         <div className={props.isInputLabelDarker ? s.darkerInputLabel : s.inputLabel}>
             {props.label}
         </div>
-        <div className={s.staticHeight}>
+        <div
+            className={classnames(
+                s.inputField,
+                s.staticHeight,
+                props.isInputColorRed ? s.redInputText : null
+            )}
+        >
             {props.value instanceof Date
                 ? Moment(props.value!).format(
                       props.isTimeIncluded ? 'DD.MM.YYYY HH:mm' : 'DD.MM.YYYY'

--- a/src/components/controls/TextContainer.tsx
+++ b/src/components/controls/TextContainer.tsx
@@ -7,12 +7,12 @@ interface ITextContainerProps {
     label: string | JSX.Element;
     value?: string | number | null | Date;
     isTimeIncluded?: boolean;
-    darkerInputLabel?: boolean;
+    isInputLabelDarker?: boolean;
 }
 
 const TextContainer = observer((props: ITextContainerProps) => (
     <div className={s.formItem}>
-        <div className={props.darkerInputLabel ? s.darkerInputLabel : s.inputLabel}>
+        <div className={props.isInputLabelDarker ? s.darkerInputLabel : s.inputLabel}>
             {props.label}
         </div>
         <div className={s.staticHeight}>

--- a/src/components/sidebar/lineView/LineInfoTab.tsx
+++ b/src/components/sidebar/lineView/LineInfoTab.tsx
@@ -211,8 +211,7 @@ class LineInfoTab extends React.Component<ILineInfoTabProps, ILineInfoTabState> 
                     </div>
                     <div className={s.flexRow}>
                         <TextContainer label='MUOKANNUT' value={line.modifiedBy} />
-                        <InputContainer
-                            disabled={true}
+                        <TextContainer
                             label='MUOKATTU PVM'
                             isTimeIncluded={true}
                             value={line.modifiedOn}

--- a/src/components/sidebar/lineView/LineInfoTab.tsx
+++ b/src/components/sidebar/lineView/LineInfoTab.tsx
@@ -211,7 +211,8 @@ class LineInfoTab extends React.Component<ILineInfoTabProps, ILineInfoTabState> 
                     </div>
                     <div className={s.flexRow}>
                         <TextContainer label='MUOKANNUT' value={line.modifiedBy} />
-                        <TextContainer
+                        <InputContainer
+                            disabled={true}
                             label='MUOKATTU PVM'
                             isTimeIncluded={true}
                             value={line.modifiedOn}

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListLink.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListLink.tsx
@@ -64,19 +64,19 @@ class RoutePathListLink extends React.Component<IRoutePathListLinkProps> {
                     <TextContainer
                         label='ALKUSOLMU'
                         value={rpLink.startNode.id}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                     <TextContainer
                         label='LOPPUSOLMU'
                         value={rpLink.endNode.id}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                 </div>
                 <div className={s.flexRow}>
                     <TextContainer
                         label='JÄRJESTYSNUMERO'
                         value={rpLink.orderNumber.toString()}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                 </div>
             </div>

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
@@ -115,12 +115,12 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                     <TextContainer
                         label='PYSÄKIN NIMI'
                         value={stop.nameFi}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                     <TextContainer
                         label='PYSÄKIN NIMI RUOTSIKSI'
                         value={stop.nameSw}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                 </div>
                 {!this.props.isLastNode && (
@@ -154,7 +154,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 items={this.props.codeListStore!.getDropdownItemList(
                                     'Ajantasaus pysakki'
                                 )}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                             <Dropdown
                                 label='ERIKOISTYYPPI'
@@ -164,7 +164,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 items={this.props.codeListStore!.getDropdownItemList(
                                     'Pysäkin käyttö'
                                 )}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                         </div>
                         <div className={s.flexRow}>
@@ -174,7 +174,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 value={routePathLink.destinationFi1}
                                 validationResult={invalidPropertiesMap['destinationFi1']}
                                 onChange={this.onRoutePathLinkPropertyChange('destinationFi1')}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                             <InputContainer
                                 label='2. MÄÄRÄNPÄÄ SUOMEKSI'
@@ -182,7 +182,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 value={routePathLink.destinationFi2}
                                 validationResult={invalidPropertiesMap['destinationFi2']}
                                 onChange={this.onRoutePathLinkPropertyChange('destinationFi2')}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                         </div>
                         <div className={s.flexRow}>
@@ -192,7 +192,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 value={routePathLink.destinationSw1}
                                 validationResult={invalidPropertiesMap['destinationSw1']}
                                 onChange={this.onRoutePathLinkPropertyChange('destinationSw1')}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                             <InputContainer
                                 label='2. MÄÄRÄNPÄÄ RUOTSIKSI'
@@ -200,7 +200,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                                 value={routePathLink.destinationSw2}
                                 validationResult={invalidPropertiesMap['destinationSw2']}
                                 onChange={this.onRoutePathLinkPropertyChange('destinationSw2')}
-                                darkerInputLabel={true}
+                                isInputLabelDarker={true}
                             />
                         </div>
                     </>
@@ -225,20 +225,20 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                         )}
                         value={startNodeBookScheduleColumnNumber}
                         validationResult={invalidPropertiesMap['startNodeBookScheduleColumnNumber']}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                 </div>
                 <div className={s.flexRow}>
                     <TextContainer
                         label='MUOKANNUT'
                         value={routePathLink.modifiedBy}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                     <TextContainer
                         label='MUOKATTU PVM'
                         isTimeIncluded={true}
                         value={routePathLink.modifiedOn}
-                        darkerInputLabel={true}
+                        isInputLabelDarker={true}
                     />
                 </div>
             </div>
@@ -251,7 +251,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                 <TextContainer
                     label='MITTAUSPÄIVÄMÄÄRÄ'
                     value={node.measurementDate}
-                    darkerInputLabel={true}
+                    isInputLabelDarker={true}
                 />
             </div>
         );


### PR DESCRIPTION
Closes #1143 

Changed plan a bit. Instead of removing TextContainer, noew InputContainer uses TextContainer. We have both TextContainer and InputContainer because
1) TextContainer is simplier and easier to read
2) InputContainer can also display validation errors, TextContainer is never supposed to be editable so it doesn't have to display validation errors