### PR TITLE
Navigator.goTo shows unsaved changes prompt

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -92,7 +92,7 @@ class App extends React.Component<IAppProps, IAppState> {
             } else {
                 // Redirect to login
                 LocalStorageHelper.setItem('origin_url', navigator.getFullPath());
-                navigator.goTo(SubSites.login);
+                navigator.goTo({ link: SubSites.login });
             }
         }
 
@@ -108,11 +108,11 @@ class App extends React.Component<IAppProps, IAppState> {
                 const originUrl = LocalStorageHelper.getItem('origin_url');
                 const destination = originUrl ? originUrl : SubSites.home;
                 LocalStorageHelper.removeItem('origin_url');
-                navigator.goTo(destination);
+                navigator.goTo({ link: destination });
             },
             () => {
                 // On error
-                navigator.goTo(SubSites.login);
+                navigator.goTo({ link: SubSites.login });
                 AuthService.logout();
                 return null;
             }

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -39,8 +39,8 @@ class NavigationBar extends Component<INavigationBarProps, INavigationBarState> 
     }
 
     private goToHomeView = () => {
-        const homeLink = routeBuilder.to(SubSites.home).toLink();
-        navigator.goTo(homeLink);
+        const homeViewLink = routeBuilder.to(SubSites.home).toLink();
+        navigator.goTo({ link: homeViewLink });
     };
 
     private syncLocalDatabase = async () => {

--- a/src/components/map/layers/RoutePathLayer.tsx
+++ b/src/components/map/layers/RoutePathLayer.tsx
@@ -31,7 +31,7 @@ class RoutePathLayer extends Component<RoutePathLayerProps> {
             )
             .append(QueryParams.showItem, routePathLinkId)
             .toLink();
-        navigator.goTo(routePathViewLink);
+        navigator.goTo({ link: routePathViewLink });
     };
 
     render() {

--- a/src/components/map/layers/RoutePathLinkLayer.tsx
+++ b/src/components/map/layers/RoutePathLinkLayer.tsx
@@ -66,11 +66,11 @@ class RoutePathLinkLayer extends Component<RoutePathLinkLayerProps> {
 
     private openNode = (node: INode, popupId: number) => () => {
         this.props.popupStore!.closePopup(popupId);
-        const nodeLink = routeBuilder
+        const nodeViewLink = routeBuilder
             .to(SubSites.node)
             .toTarget(':id', node.id)
             .toLink();
-        navigator.goTo(nodeLink);
+        navigator.goTo({ link: nodeViewLink });
     };
 
     private renderRoutePathLinks = () => {

--- a/src/components/map/layers/popups/SelectNetworkEntityPopup.tsx
+++ b/src/components/map/layers/popups/SelectNetworkEntityPopup.tsx
@@ -33,25 +33,17 @@ class SelectNetworkEntityPopup extends Component<ISelectNetworkEntityPopupProps>
         this.props.highlightEntityStore!.setNodes(nodes);
     };
 
-    private promptRedirectToNode = (nodeId: string, popupId: number) => {
-        const redirectToNode = () => {
-            this.props.popupStore!.closePopup(popupId);
-            this.props.highlightEntityStore!.setNodes([]);
-            const nodeViewLink = routeBuilder
-                .to(SubSites.node)
-                .toTarget(':id', nodeId)
-                .toLink();
-            navigator.goTo(nodeViewLink);
-        };
-        if (this.props.toolbarStore!.shouldShowEntityOpenPrompt) {
-            this.props.confirmStore!.openConfirm({
-                content: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata solmun ${nodeId}? Tallentamattomat muutokset kumotaan.`,
-                onConfirm: redirectToNode,
-                confirmButtonText: 'Kyllä'
-            });
-        } else {
-            redirectToNode();
-        }
+    private redirectToNode = (nodeId: string, popupId: number) => {
+        this.props.popupStore!.closePopup(popupId);
+        this.props.highlightEntityStore!.setNodes([]);
+        const nodeViewLink = routeBuilder
+            .to(SubSites.node)
+            .toTarget(':id', nodeId)
+            .toLink();
+        navigator.goTo({
+            link: nodeViewLink,
+            unsavedChangesPromptMessage: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata solmun ${nodeId}? Tallentamattomat muutokset kumotaan.`
+        });
     };
 
     private highlightLink = (link: ILinkMapHighlight, isHighlighted: boolean) => {
@@ -59,25 +51,17 @@ class SelectNetworkEntityPopup extends Component<ISelectNetworkEntityPopupProps>
         this.props.highlightEntityStore!.setLinks(links);
     };
 
-    private promptRedirectToLink = (link: ILinkMapHighlight, popupId: number) => {
-        const redirectToLink = () => {
-            this.props.popupStore!.closePopup(popupId);
-            this.props.highlightEntityStore!.setLinks([]);
-            const linkViewLink = routeBuilder
-                .to(SubSites.link)
-                .toTarget(':id', [link.startNodeId, link.endNodeId, link.transitType].join(','))
-                .toLink();
-            navigator.goTo(linkViewLink);
-        };
-        if (this.props.toolbarStore!.shouldShowEntityOpenPrompt) {
-            this.props.confirmStore!.openConfirm({
-                content: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata linkin? Tallentamattomat muutokset kumotaan.`,
-                onConfirm: redirectToLink,
-                confirmButtonText: 'Kyllä'
-            });
-        } else {
-            redirectToLink();
-        }
+    private redirectToLink = (link: ILinkMapHighlight, popupId: number) => {
+        this.props.popupStore!.closePopup(popupId);
+        this.props.highlightEntityStore!.setLinks([]);
+        const linkViewLink = routeBuilder
+            .to(SubSites.link)
+            .toTarget(':id', [link.startNodeId, link.endNodeId, link.transitType].join(','))
+            .toLink();
+        navigator.goTo({
+            link: linkViewLink,
+            unsavedChangesPromptMessage: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata linkin? Tallentamattomat muutokset kumotaan.`
+        });
     };
 
     render() {
@@ -90,7 +74,7 @@ class SelectNetworkEntityPopup extends Component<ISelectNetworkEntityPopupProps>
                             className={s.row}
                             onMouseOver={() => this.highlightNode(node, true)}
                             onMouseOut={() => this.highlightNode(node, false)}
-                            onClick={() => this.promptRedirectToNode(node.id, this.props.popupId)}
+                            onClick={() => this.redirectToNode(node.id, this.props.popupId)}
                         >
                             Solmu {node.id}
                         </div>
@@ -103,7 +87,7 @@ class SelectNetworkEntityPopup extends Component<ISelectNetworkEntityPopupProps>
                             className={s.row}
                             onMouseOver={() => this.highlightLink(link, true)}
                             onMouseOut={() => this.highlightLink(link, false)}
-                            onClick={() => this.promptRedirectToLink(link, this.props.popupId)}
+                            onClick={() => this.redirectToLink(link, this.props.popupId)}
                         >
                             Linkki
                         </div>

--- a/src/components/map/tools/AddNetworkLinkTool.ts
+++ b/src/components/map/tools/AddNetworkLinkTool.ts
@@ -60,7 +60,7 @@ class AddNetworkLinkTool implements BaseTool {
             .to(SubSites.newLink)
             .toTarget(':id', [this.startNodeId, this.endNodeId].join(','))
             .toLink();
-        navigator.goTo(newLinkViewLink);
+        navigator.goTo({ link: newLinkViewLink });
         ToolbarStore.selectTool(null);
     };
 

--- a/src/components/map/tools/AddNetworkNodeTool.ts
+++ b/src/components/map/tools/AddNetworkNodeTool.ts
@@ -29,10 +29,10 @@ class AddNetworkNodeTool implements BaseTool {
     private onMapClick = async (clickEvent: CustomEvent) => {
         ToolbarStore.selectTool(null);
         const coordinate = roundLatLng(clickEvent.detail.latlng);
-        const url = RouteBuilder.to(SubSites.newNode)
+        const newNodeViewLink = RouteBuilder.to(SubSites.newNode)
             .toTarget(':id', `${coordinate.lat}:${coordinate.lng}`)
             .toLink();
-        navigator.goTo(url);
+        navigator.goTo({ link: newNodeViewLink });
     };
 }
 

--- a/src/components/map/tools/SelectNetworkEntityTool.ts
+++ b/src/components/map/tools/SelectNetworkEntityTool.ts
@@ -8,11 +8,9 @@ import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import LinkService from '~/services/linkService';
 import NodeService from '~/services/nodeService';
-import ConfirmStore from '~/stores/confirmStore';
 import MapStore from '~/stores/mapStore';
 import NetworkStore, { MapLayer } from '~/stores/networkStore';
 import PopupStore, { IPopupProps } from '~/stores/popupStore';
-import ToolbarStore from '~/stores/toolbarStore';
 import EventManager from '~/util/EventManager';
 import { isNetworkElementHidden, isNetworkNodeHidden } from '~/util/networkUtils';
 import { ISelectNetworkEntityPopupData } from '../layers/popups/SelectNetworkEntityPopup';
@@ -104,11 +102,11 @@ class SelectNetworkEntityTool implements BaseTool {
 
         if (nodes.length === 0 && links.length === 0) return;
         if (nodes.length === 1 && links.length === 0) {
-            _promptRedirectToNode(nodes[0]);
+            _redirectToNode(nodes[0]);
             return;
         }
         if (links.length === 1 && nodes.length === 0) {
-            _promptRedirectToLink(links[0]);
+            _redirectToLink(links[0]);
             return;
         }
 
@@ -128,45 +126,28 @@ class SelectNetworkEntityTool implements BaseTool {
     };
 }
 
-const _promptRedirectToNode = (node: INodeMapHighlight) => {
-    const _redirectToNode = () => {
-        const nodeViewLink = routeBuilder
-            .to(SubSites.node)
-            .toTarget(':id', node.id)
-            .toLink();
-        navigator.goTo(nodeViewLink);
-    };
-
-    if (ToolbarStore!.shouldShowEntityOpenPrompt) {
-        ConfirmStore!.openConfirm({
-            content: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata solmun ${
-                node.id
-            }? Tallentamattomat muutokset kumotaan.`,
-            onConfirm: _redirectToNode,
-            confirmButtonText: 'Kyllä'
-        });
-    } else {
-        _redirectToNode();
-    }
+const _redirectToNode = (node: INodeMapHighlight) => {
+    const nodeViewLink = routeBuilder
+        .to(SubSites.node)
+        .toTarget(':id', node.id)
+        .toLink();
+    navigator.goTo({
+        link: nodeViewLink,
+        unsavedChangesPromptMessage: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata solmun ${
+            node.id
+        }? Tallentamattomat muutokset kumotaan.`
+    });
 };
 
-const _promptRedirectToLink = (link: ILinkMapHighlight) => {
-    const _redirectToLink = () => {
-        const linkViewLink = routeBuilder
-            .to(SubSites.link)
-            .toTarget(':id', [link.startNodeId, link.endNodeId, link.transitType].join(','))
-            .toLink();
-        navigator.goTo(linkViewLink);
-    };
-    if (ToolbarStore!.shouldShowEntityOpenPrompt) {
-        ConfirmStore!.openConfirm({
-            content: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata linkin? Tallentamattomat muutokset kumotaan.`,
-            onConfirm: _redirectToLink,
-            confirmButtonText: 'Kyllä'
-        });
-    } else {
-        _redirectToLink();
-    }
+const _redirectToLink = (link: ILinkMapHighlight) => {
+    const linkViewLink = routeBuilder
+        .to(SubSites.link)
+        .toTarget(':id', [link.startNodeId, link.endNodeId, link.transitType].join(','))
+        .toLink();
+    navigator.goTo({
+        link: linkViewLink,
+        unsavedChangesPromptMessage: `Sinulla on tallentamattomia muutoksia. Haluatko varmasti avata linkin? Tallentamattomat muutokset kumotaan.`
+    });
 };
 
 export default SelectNetworkEntityTool;

--- a/src/components/map/tools/SplitLinkTool.ts
+++ b/src/components/map/tools/SplitLinkTool.ts
@@ -32,13 +32,13 @@ class SplitLinkTool implements BaseTool {
     navigateToSplitLink = (nodeId: string) => {
         const link = LinkStore.link;
         if (!link) throw 'Valittua linkkiä ei löytynyt.';
-        const url = RouteBuilder.to(SubSites.splitLink)
+        const splitLinkViewLink = RouteBuilder.to(SubSites.splitLink)
             .toTarget(
                 ':id',
                 [link.startNode.id, link.endNode.id, link.transitType, nodeId].join(',')
             )
             .toLink();
-        navigator.goTo(url);
+        navigator.goTo({ link: splitLinkViewLink });
     };
 
     private openNodeConfirm = async (clickEvent: CustomEvent) => {

--- a/src/components/shared/searchView/LineItem.tsx
+++ b/src/components/shared/searchView/LineItem.tsx
@@ -18,12 +18,12 @@ interface ILineItemProps {
 
 class LineItem extends React.Component<ILineItemProps> {
     private openRoute = (routeId: string) => () => {
-        const openRouteLink = routeBuilder
+        const routeViewLink = routeBuilder
             .to(SubSites.routes, navigator.getQueryParamValues())
             .append(QueryParams.routes, routeId)
             .toLink();
         searchStore.setSearchInput('');
-        navigator.goTo(openRouteLink);
+        navigator.goTo({ link: routeViewLink });
     };
 
     private renderRoute(route: ISearchLineRoute): any {
@@ -50,11 +50,11 @@ class LineItem extends React.Component<ILineItemProps> {
     }
 
     private redirectToLineView = (lineId: string) => () => {
-        const url = routeBuilder
+        const lineViewLink = routeBuilder
             .to(SubSites.line)
             .toTarget(':id', lineId)
             .toLink();
-        navigator.goTo(url);
+        navigator.goTo({ link: lineViewLink });
     };
 
     public render() {

--- a/src/components/shared/searchView/NodeItem.tsx
+++ b/src/components/shared/searchView/NodeItem.tsx
@@ -14,11 +14,11 @@ interface INodeItemProps {
 
 const NodeItem = observer((props: INodeItemProps) => {
     const openNode = () => {
-        const nodeLink = routeBuilder
+        const nodeViewLink = routeBuilder
             .to(SubSites.node)
             .toTarget(':id', props.node.id)
             .toLink();
-        navigator.goTo(nodeLink);
+        navigator.goTo({ link: nodeViewLink });
     };
 
     return (

--- a/src/components/sidebar/PageNotFoundView.tsx
+++ b/src/components/sidebar/PageNotFoundView.tsx
@@ -17,8 +17,8 @@ class PageNotFoundView extends Component<IPageNotFoundViewProps> {
         this.props.mapStore!.initCoordinates();
     }
     private goToHomeView = () => {
-        const homeLink = routeBuilder.to(SubSites.home).toLink();
-        navigator.goTo(homeLink);
+        const homeViewLink = routeBuilder.to(SubSites.home).toLink();
+        navigator.goTo({ link: homeViewLink });
     };
 
     render() {

--- a/src/components/sidebar/SidebarHeader.tsx
+++ b/src/components/sidebar/SidebarHeader.tsx
@@ -16,7 +16,6 @@ interface ISidebarHeaderProps {
     isBackButtonVisible?: boolean;
     isEditButtonVisible?: boolean;
     isEditing?: boolean;
-    shouldShowClosePromptMessage?: boolean;
     shouldShowEditButtonClosePromptMessage?: boolean;
     onEditButtonClick?: () => void;
     onBackButtonClick?: () => void;

--- a/src/components/sidebar/SidebarHeader.tsx
+++ b/src/components/sidebar/SidebarHeader.tsx
@@ -16,7 +16,6 @@ interface ISidebarHeaderProps {
     isBackButtonVisible?: boolean;
     isEditButtonVisible?: boolean;
     isEditing?: boolean;
-    shouldShowEditButtonClosePromptMessage?: boolean;
     onEditButtonClick?: () => void;
     onBackButtonClick?: () => void;
     onCloseButtonClick?: () => void;

--- a/src/components/sidebar/SidebarHeader.tsx
+++ b/src/components/sidebar/SidebarHeader.tsx
@@ -32,6 +32,18 @@ const revertPromptMessage =
 @inject('loginStore', 'confirmStore', 'navigationStore')
 @observer
 class SidebarHeader extends React.Component<ISidebarHeaderProps> {
+    private onEditButtonClick = () => {
+        if (this.props.navigationStore!.shouldShowUnsavedChangesPrompt) {
+            this.props.confirmStore!.openConfirm({
+                content: revertPromptMessage,
+                onConfirm: this.props.onEditButtonClick!,
+                confirmButtonText: 'Kyllä'
+            });
+        } else {
+            this.props.onEditButtonClick!();
+        }
+    };
+
     private onBackButtonClick = () => {
         const defaultOnClick = () => {
             navigator.goBack({ unsavedChangesPromptMessage: closePromptMessage });
@@ -43,6 +55,8 @@ class SidebarHeader extends React.Component<ISidebarHeaderProps> {
                     onConfirm: this.props.onBackButtonClick!,
                     confirmButtonText: 'Kyllä'
                 });
+            } else {
+                this.props.onBackButtonClick();
             }
         } else {
             defaultOnClick();
@@ -61,21 +75,11 @@ class SidebarHeader extends React.Component<ISidebarHeaderProps> {
                     onConfirm: this.props.onCloseButtonClick!,
                     confirmButtonText: 'Kyllä'
                 });
+            } else {
+                this.props.onCloseButtonClick();
             }
         } else {
             defaultOnClick();
-        }
-    };
-
-    private onEditButtonClick = () => {
-        if (this.props.navigationStore!.shouldShowUnsavedChangesPrompt) {
-            this.props.confirmStore!.openConfirm({
-                content: revertPromptMessage,
-                onConfirm: this.props.onEditButtonClick!,
-                confirmButtonText: 'Kyllä'
-            });
-        } else {
-            this.props.onEditButtonClick!();
         }
     };
 

--- a/src/components/sidebar/SidebarHeader.tsx
+++ b/src/components/sidebar/SidebarHeader.tsx
@@ -50,10 +50,10 @@ class SidebarHeader extends React.Component<ISidebarHeaderProps> {
     };
 
     private onCloseButtonClick = () => {
-        const homeLink = routeBuilder.to(SubSites.home).toLink();
+        const homeViewLink = routeBuilder.to(SubSites.home).toLink();
         this.optionalConfirmPrompt({
             message: closePromptMessage,
-            defaultOnClick: () => navigator.goTo(homeLink),
+            defaultOnClick: () => navigator.goTo({ link: homeViewLink }),
             customOnClick: this.props.onCloseButtonClick,
             shouldShowMessage: this.props.shouldShowClosePromptMessage
         });

--- a/src/components/sidebar/homeView/HomeView.tsx
+++ b/src/components/sidebar/homeView/HomeView.tsx
@@ -32,8 +32,8 @@ class HomeView extends React.Component<IHomeViewProps> {
     }
 
     private redirectToNewLineView = () => {
-        const url = RouteBuilder.to(SubSites.newLine).toLink();
-        navigator.goTo(url);
+        const newLineViewLink = RouteBuilder.to(SubSites.newLine).toLink();
+        navigator.goTo({ link: newLineViewLink });
     };
 
     render() {

--- a/src/components/sidebar/lineView/LineHeaderTable.tsx
+++ b/src/components/sidebar/lineView/LineHeaderTable.tsx
@@ -237,7 +237,6 @@ class LineHeaderTable extends React.Component<ILineHeaderListProps, ILineHeaderS
                     isCloseButtonVisible={true}
                     isBackButtonVisible={true}
                     isEditButtonVisible={currentLineHeaders.length > 0}
-                    shouldShowClosePromptMessage={lineHeaderMassEditStore!.isDirty}
                 >
                     Linjan otsikot
                 </SidebarHeader>

--- a/src/components/sidebar/lineView/LineRoutesTab.tsx
+++ b/src/components/sidebar/lineView/LineRoutesTab.tsx
@@ -25,12 +25,12 @@ class LineRoutesTab extends React.Component<ILineRoutesTabProps> {
     private redirectToNewRouteView = () => {
         const line = this.props.lineStore!.line;
 
-        const newRouteLink = routeBuilder
+        const newRouteViewLink = routeBuilder
             .to(SubSites.newRoute)
             .set(QueryParams.lineId, line!.id)
             .toLink();
 
-        navigator.goTo(newRouteLink);
+        navigator.goTo({ link: newRouteViewLink });
     };
 
     private renderRouteList = (routes: IRoute[]) => {
@@ -59,12 +59,12 @@ class LineRoutesTab extends React.Component<ILineRoutesTabProps> {
     };
 
     private redirectToRouteView = (routeId: string) => () => {
-        const openRouteLink = routeBuilder
+        const routeViewLink = routeBuilder
             .to(SubSites.routes, navigator.getQueryParamValues())
             .append(QueryParams.routes, routeId)
             .toLink();
         this.props.searchStore!.setSearchInput('');
-        navigator.goTo(openRouteLink);
+        navigator.goTo({ link: routeViewLink });
     };
 
     render() {

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -172,7 +172,6 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
                         isEditButtonVisible={!this.props.isNewLine}
                         onEditButtonClick={lineStore!.toggleIsEditingDisabled}
                         isEditing={!lineStore!.isEditingDisabled}
-                        shouldShowEditButtonClosePromptMessage={lineStore!.isDirty}
                     >
                         {this.props.isNewLine ? 'Luo uusi linja' : `Linja ${lineStore!.line!.id}`}
                     </SidebarHeader>

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -13,7 +13,6 @@ import RouteService from '~/services/routeService';
 import { AlertStore } from '~/stores/alertStore';
 import { ConfirmStore } from '~/stores/confirmStore';
 import { ErrorStore } from '~/stores/errorStore';
-import { LineHeaderMassEditStore } from '~/stores/lineHeaderMassEditStore';
 import { LineStore } from '~/stores/lineStore';
 import { MapStore } from '~/stores/mapStore';
 import SidebarHeader from '../SidebarHeader';
@@ -26,7 +25,6 @@ interface ILineViewProps {
     isNewLine: boolean;
     alertStore?: AlertStore;
     errorStore?: ErrorStore;
-    lineHeaderMassEditStore?: LineHeaderMassEditStore;
     lineStore?: LineStore;
     confirmStore?: ConfirmStore;
     mapStore?: MapStore;
@@ -37,14 +35,7 @@ interface ILineViewState {
     selectedTabIndex: number;
 }
 
-@inject(
-    'lineStore',
-    'lineHeaderMassEditStore',
-    'errorStore',
-    'alertStore',
-    'mapStore',
-    'confirmStore'
-)
+@inject('lineStore', 'errorStore', 'alertStore', 'mapStore', 'confirmStore')
 @observer
 class LineView extends React.Component<ILineViewProps, ILineViewState> {
     constructor(props: ILineViewProps) {
@@ -163,7 +154,6 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
 
     render() {
         const lineStore = this.props.lineStore;
-        const lineHeaderMassEditStore = this.props.lineHeaderMassEditStore;
         if (this.state.isLoading) {
             return (
                 <div className={s.lineView}>
@@ -182,9 +172,6 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
                         isEditButtonVisible={!this.props.isNewLine}
                         onEditButtonClick={lineStore!.toggleIsEditingDisabled}
                         isEditing={!lineStore!.isEditingDisabled}
-                        shouldShowClosePromptMessage={
-                            lineStore!.isDirty || lineHeaderMassEditStore!.isDirty
-                        }
                         shouldShowEditButtonClosePromptMessage={lineStore!.isDirty}
                     >
                         {this.props.isNewLine ? 'Luo uusi linja' : `Linja ${lineStore!.line!.id}`}

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -140,7 +140,7 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
             .to(SubSites.line)
             .toTarget(':id', line!.id)
             .toLink();
-        navigator.goTo({ link: lineViewLink });
+        navigator.goTo({ link: lineViewLink, shouldSkipUnsavedChangesPrompt: true });
     };
 
     private showSavePrompt = () => {

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -140,7 +140,7 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
             .to(SubSites.line)
             .toTarget(':id', line!.id)
             .toLink();
-        navigator.goTo(lineViewLink);
+        navigator.goTo({ link: lineViewLink });
     };
 
     private showSavePrompt = () => {

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -251,7 +251,6 @@ class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
                     <SidebarHeader
                         isEditButtonVisible={!this.props.isNewLink}
                         isEditing={!isEditingDisabled}
-                        shouldShowClosePromptMessage={this.props.linkStore!.isDirty!}
                         onEditButtonClick={this.props.linkStore!.toggleIsEditingDisabled}
                     >
                         Linkki

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -186,7 +186,7 @@ class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
             .to(SubSites.link)
             .toTarget(':id', [link.startNode.id, link.endNode.id, link.transitType].join(','))
             .toLink();
-        navigator.goTo({ link: linkViewLink });
+        navigator.goTo({ link: linkViewLink, shouldSkipUnsavedChangesPrompt: true });
     };
 
     private navigateToNode = (nodeId: string) => () => {

--- a/src/components/sidebar/linkView/LinkView.tsx
+++ b/src/components/sidebar/linkView/LinkView.tsx
@@ -156,7 +156,7 @@ class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
         }
 
         if (this.props.isNewLink) {
-            this.navigateToNewLink();
+            this.navigateToCreatedLink();
             return;
         }
         this.setState({ isLoading: false });
@@ -180,21 +180,21 @@ class LinkView extends React.Component<ILinkViewProps, ILinkViewState> {
         });
     };
 
-    private navigateToNewLink = () => {
+    private navigateToCreatedLink = () => {
         const link = this.props.linkStore!.link;
         const linkViewLink = routeBuilder
             .to(SubSites.link)
             .toTarget(':id', [link.startNode.id, link.endNode.id, link.transitType].join(','))
             .toLink();
-        navigator.goTo(linkViewLink);
+        navigator.goTo({ link: linkViewLink });
     };
 
     private navigateToNode = (nodeId: string) => () => {
-        const editNetworkLink = routeBuilder
+        const nodeViewLink = routeBuilder
             .to(SubSites.node)
             .toTarget(':id', nodeId)
             .toLink();
-        navigator.goTo(editNetworkLink);
+        navigator.goTo({ link: nodeViewLink });
     };
 
     private selectTransitType = (transitType: TransitType) => {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -259,7 +259,7 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
                     .to(SubSites.node)
                     .toTarget(':id', nodeId)
                     .toLink();
-                navigator.goTo({ link: nodeViewLink });
+                navigator.goTo({ link: nodeViewLink, shouldSkipUnsavedChangesPrompt: true });
                 this.props.nodeStore!.clearNodeCache({ shouldClearNewNodeCache: true });
             } else {
                 await NodeService.updateNode(

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -418,7 +418,6 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
                 <div className={s.content}>
                     <SidebarHeader
                         isEditButtonVisible={!isNewNode}
-                        shouldShowClosePromptMessage={nodeStore.isDirty}
                         isEditing={!isEditingDisabled}
                         onEditButtonClick={nodeStore.toggleIsEditingDisabled}
                     >

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -260,13 +260,14 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
                     .toTarget(':id', nodeId)
                     .toLink();
                 navigator.goTo({ link: nodeViewLink });
+                this.props.nodeStore!.clearNodeCache({ shouldClearNewNodeCache: true });
             } else {
                 await NodeService.updateNode(
                     this.props.nodeStore!.node,
                     this.props.nodeStore!.getDirtyLinks()
                 );
+                this.props.nodeStore!.clearNodeCache({ nodeId: this.props.nodeStore!.node.id });
             }
-            this.props.nodeStore!.clearNodeCache();
             this.props.nodeStore!.setCurrentStateAsOld();
             this.props.alertStore!.setFadeMessage({ message: 'Tallennettu!' });
         } catch (e) {

--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -255,11 +255,11 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
                     nodeToUpdate = this.props.nodeStore!.node;
                 }
                 const nodeId = await NodeService.createNode(nodeToUpdate);
-                const url = routeBuilder
+                const nodeViewLink = routeBuilder
                     .to(SubSites.node)
                     .toTarget(':id', nodeId)
                     .toLink();
-                navigator.goTo(url);
+                navigator.goTo({ link: nodeViewLink });
             } else {
                 await NodeService.updateNode(
                     this.props.nodeStore!.node,

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -69,27 +69,27 @@ class StopForm extends Component<IStopFormProps> {
         const routePathViewLink = RouteBuilder.to(SubSites.stopArea)
             .toTarget(':id', stopAreaId!)
             .toLink();
-        navigator.goTo(routePathViewLink);
+        navigator.goTo({ link: routePathViewLink });
     };
 
     private redirectToNewStopArea = () => {
         this.props.setCurrentStateIntoNodeCache!();
         const node = this.props.node;
-        let url;
+        let link;
         if (this.props.isNewStop) {
-            url = RouteBuilder.to(SubSites.newStopArea)
+            link = RouteBuilder.to(SubSites.newStopArea)
                 .append(
                     QueryParams.latLng,
                     `${node.coordinatesProjection.lat}:${node.coordinatesProjection.lng}`
                 )
                 .toLink();
         } else {
-            url = RouteBuilder.to(SubSites.newStopArea)
+            link = RouteBuilder.to(SubSites.newStopArea)
                 .append(QueryParams.nodeId, node.id)
                 .toLink();
         }
 
-        navigator.goTo(url);
+        navigator.goTo({ link });
     };
 
     render() {

--- a/src/components/sidebar/nodeView/StopForm.tsx
+++ b/src/components/sidebar/nodeView/StopForm.tsx
@@ -69,7 +69,7 @@ class StopForm extends Component<IStopFormProps> {
         const routePathViewLink = RouteBuilder.to(SubSites.stopArea)
             .toTarget(':id', stopAreaId!)
             .toLink();
-        navigator.goTo({ link: routePathViewLink });
+        navigator.goTo({ link: routePathViewLink, shouldSkipUnsavedChangesPrompt: true });
     };
 
     private redirectToNewStopArea = () => {
@@ -89,7 +89,7 @@ class StopForm extends Component<IStopFormProps> {
                 .toLink();
         }
 
-        navigator.goTo({ link });
+        navigator.goTo({ link, shouldSkipUnsavedChangesPrompt: true });
     };
 
     render() {

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -258,7 +258,6 @@ class StopAreaView extends React.Component<IStopAreaViewProps, IStopAreaViewStat
                     <SidebarHeader
                         isEditButtonVisible={!this.props.isNewStopArea}
                         isEditing={!isEditingDisabled}
-                        shouldShowClosePromptMessage={stopAreaStore.isDirty!}
                         onEditButtonClick={stopAreaStore.toggleIsEditingDisabled}
                     >
                         {this.props.isNewStopArea ? 'Luo uusi pysäkkialue' : 'Pysäkkialue'}

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -150,14 +150,14 @@ class StopAreaView extends React.Component<IStopAreaViewProps, IStopAreaViewStat
                         .toTarget(':id', latLng)
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
-                    navigator.goTo({ link: newNodeLink });
+                    navigator.goTo({ link: newNodeLink, shouldSkipUnsavedChangesPrompt: true });
                 } else {
                     const nodeLink = routeBuilder
                         .to(SubSites.node)
                         .toTarget(':id', nodeId)
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
-                    navigator.goTo({ link: nodeLink });
+                    navigator.goTo({ link: nodeLink, shouldSkipUnsavedChangesPrompt: true });
                 }
             } else {
                 await StopAreaService.updateStopArea(this.props.stopAreaStore!.stopArea);

--- a/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
+++ b/src/components/sidebar/nodeView/stopAreaView/StopAreaView.tsx
@@ -145,19 +145,19 @@ class StopAreaView extends React.Component<IStopAreaViewProps, IStopAreaViewStat
                 const latLngQueryParam = navigator.getQueryParam(QueryParams.latLng);
                 const latLng = latLngQueryParam ? latLngQueryParam[0] : undefined;
                 if (latLng) {
-                    const url = routeBuilder
+                    const newNodeLink = routeBuilder
                         .to(SubSites.newNode)
                         .toTarget(':id', latLng)
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
-                    navigator.goTo(url);
+                    navigator.goTo({ link: newNodeLink });
                 } else {
-                    const url = routeBuilder
+                    const nodeLink = routeBuilder
                         .to(SubSites.node)
                         .toTarget(':id', nodeId)
                         .append(QueryParams.stopAreaId, stopAreaId)
                         .toLink();
-                    navigator.goTo(url);
+                    navigator.goTo({ link: nodeLink });
                 }
             } else {
                 await StopAreaService.updateStopArea(this.props.stopAreaStore!.stopArea);

--- a/src/components/sidebar/routeListView/RouteList.tsx
+++ b/src/components/sidebar/routeListView/RouteList.tsx
@@ -125,7 +125,7 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
             .set(QueryParams.lineId, route.lineId)
             .toLink();
 
-        navigator.goTo(newRoutePathLink);
+        navigator.goTo({ link: newRoutePathLink });
     };
 
     private closeRoutePrompt = (route: IRoute) => {
@@ -149,7 +149,7 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
             .to(SubSites.current, navigator.getQueryParamValues())
             .remove(QueryParams.routes, route.id)
             .toLink();
-        navigator.goTo(closeRouteLink);
+        navigator.goTo({ link: closeRouteLink });
     };
 
     private editRoutePrompt = (route: IRoute) => {

--- a/src/components/sidebar/routeListView/RouteListView.tsx
+++ b/src/components/sidebar/routeListView/RouteListView.tsx
@@ -29,8 +29,8 @@ class RouteListView extends React.Component<IRouteListViewProps> {
 
     componentDidUpdate() {
         if (!navigator.getQueryParam(QueryParams.routes)) {
-            const homeLink = routeBuilder.to(subSites.home).toLink();
-            navigator.goTo(homeLink);
+            const homeViewLink = routeBuilder.to(subSites.home).toLink();
+            navigator.goTo({ link: homeViewLink });
         }
     }
 

--- a/src/components/sidebar/routeListView/RoutePathListTab.tsx
+++ b/src/components/sidebar/routeListView/RoutePathListTab.tsx
@@ -61,7 +61,7 @@ class RoutePathListTab extends React.Component<IRouteItemProps> {
                         ].join(',')
                     )
                     .toLink();
-                navigator.goTo(routePathViewLink);
+                navigator.goTo({ link: routePathViewLink });
             };
 
             const isWithinTimeSpan =

--- a/src/components/sidebar/routePathView/RoutePathHeader.tsx
+++ b/src/components/sidebar/routePathView/RoutePathHeader.tsx
@@ -6,7 +6,6 @@ import SidebarHeader from '../SidebarHeader';
 import * as s from './routePathView.scss';
 
 interface IRoutePathHeaderProps {
-    hasModifications?: boolean;
     routePath: IRoutePath;
     isNewRoutePath: boolean;
     isEditing: boolean;
@@ -19,7 +18,6 @@ const RoutePathHeader = observer((props: IRoutePathHeaderProps) => (
             isEditButtonVisible={!props.isNewRoutePath}
             onEditButtonClick={props.onEditButtonClick}
             isEditing={props.isEditing}
-            shouldShowClosePromptMessage={props.hasModifications!}
         >
             {props.isNewRoutePath
                 ? 'Uusi reitinsuunta'

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -245,14 +245,14 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
 
     private save = async () => {
         this.setState({ isLoading: true });
-        let redirectUrl: string | undefined;
+        let routePathViewLink: string | undefined;
         const routePath = this.props.routePathStore!.routePath;
         try {
             if (this.props.isNewRoutePath) {
                 const routePathPrimaryKey = await RoutePathService.createRoutePath(
                     routePath!
                 );
-                redirectUrl = routeBuilder
+                routePathViewLink = routeBuilder
                     .to(SubSites.routePath)
                     .toTarget(
                         ':id',
@@ -277,8 +277,8 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
         } catch (e) {
             this.props.errorStore!.addError(`Tallennus epäonnistui`, e);
         }
-        if (redirectUrl) {
-            navigator.goTo(redirectUrl);
+        if (routePathViewLink) {
+            navigator.goTo({ link: routePathViewLink });
             return;
         }
         await this.fetchRoutePath();

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -278,7 +278,7 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
             this.props.errorStore!.addError(`Tallennus epäonnistui`, e);
         }
         if (routePathViewLink) {
-            navigator.goTo({ link: routePathViewLink });
+            navigator.goTo({ link: routePathViewLink, shouldSkipUnsavedChangesPrompt: true });
             return;
         }
         await this.fetchRoutePath();

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -328,7 +328,6 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
         return (
             <div className={s.routePathView}>
                 <RoutePathHeader
-                    hasModifications={routePathStore!.isDirty}
                     routePath={routePathStore!.routePath!}
                     isNewRoutePath={this.props.isNewRoutePath}
                     isEditing={!routePathStore!.isEditingDisabled}

--- a/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
+++ b/src/components/sidebar/routePathView/routePathInfoTab/RoutePathInfoTab.tsx
@@ -89,7 +89,7 @@ class RoutePathInfoTab extends React.Component<IRoutePathInfoTabProps, IRoutePat
             })
             .toLink();
 
-        navigator.goTo(newRoutePathLink);
+        navigator.goTo({ link: newRoutePathLink });
     };
 
     private fetchExistingPrimaryKeys = async (routeId: string) => {

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListLink.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListLink.tsx
@@ -92,7 +92,7 @@ class RoutePathListLink extends React.Component<IRoutePathListLinkProps> {
                 [routeLink.startNode.id, routeLink.endNode.id, routeLink.transitType].join(',')
             )
             .toLink();
-        navigator.goTo(routeLinkViewLink);
+        navigator.goTo({ link: routeLinkViewLink });
     };
 
     private renderListIcon = () => <div className={s.linkIcon} />;

--- a/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
+++ b/src/components/sidebar/routePathView/routePathListTab/RoutePathListNode.tsx
@@ -303,7 +303,7 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
                 {Boolean(this.props.node.stop) && this.renderStopView(this.props.node.stop!)}
                 {this.renderNodeView(this.props.node)}
                 <div className={s.footer}>
-                    <Button onClick={this.openInNetworkView} type={ButtonType.SQUARE}>
+                    <Button onClick={this.openNodeView} type={ButtonType.SQUARE}>
                         <div>Avaa solmu</div>
                         <FiChevronRight />
                     </Button>
@@ -312,12 +312,12 @@ class RoutePathListNode extends React.Component<IRoutePathListNodeProps> {
         );
     };
 
-    private openInNetworkView = () => {
-        const editNetworkLink = routeBuilder
+    private openNodeView = () => {
+        const nodeViewLink = routeBuilder
             .to(SubSites.node)
             .toTarget(':id', this.props.node.id)
             .toLink();
-        navigator.goTo(editNetworkLink);
+        navigator.goTo({ link: nodeViewLink });
     };
 
     private getShadowClass() {

--- a/src/components/sidebar/routeView/NewRouteView.tsx
+++ b/src/components/sidebar/routeView/NewRouteView.tsx
@@ -103,7 +103,7 @@ class NewRouteView extends React.Component<IRouteViewProps, IRouteViewState> {
             .to(SubSites.line)
             .toTarget(':id', lineId)
             .toLink();
-        navigator.goTo({ link: lineViewLink });
+        navigator.goTo({ link: lineViewLink, shouldSkipUnsavedChangesPrompt: true });
     };
 
     private onChangeRouteProperty = (property: keyof IRoute) => (value: any) => {

--- a/src/components/sidebar/routeView/NewRouteView.tsx
+++ b/src/components/sidebar/routeView/NewRouteView.tsx
@@ -99,11 +99,11 @@ class NewRouteView extends React.Component<IRouteViewProps, IRouteViewState> {
 
     private redirectToLineView = () => {
         const lineId = navigator.getQueryParam(QueryParams.lineId);
-        const url = routeBuilder
+        const lineViewLink = routeBuilder
             .to(SubSites.line)
             .toTarget(':id', lineId)
             .toLink();
-        navigator.goTo(url);
+        navigator.goTo({ link: lineViewLink });
     };
 
     private onChangeRouteProperty = (property: keyof IRoute) => (value: any) => {

--- a/src/components/sidebar/routeView/NewRouteView.tsx
+++ b/src/components/sidebar/routeView/NewRouteView.tsx
@@ -120,11 +120,7 @@ class NewRouteView extends React.Component<IRouteViewProps, IRouteViewState> {
         if (!route) return null;
         return (
             <div className={classnames(s.routeView, s.form)}>
-                <SidebarHeader
-                    isEditButtonVisible={false}
-                    isEditing={true}
-                    shouldShowClosePromptMessage={this.props.routeStore!.isDirty}
-                >
+                <SidebarHeader isEditButtonVisible={false} isEditing={true}>
                     <div>Luo uusi reitti linjalle {lineId}</div>
                 </SidebarHeader>
                 <RouteForm

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,7 @@ import LineStore from './stores/lineStore';
 import LinkStore from './stores/linkStore';
 import LoginStore from './stores/loginStore';
 import MapStore from './stores/mapStore';
+import { NavigationStore } from './stores/navigationStore';
 import NetworkStore from './stores/networkStore';
 import NodeStore from './stores/nodeStore';
 import PopupStore from './stores/popupStore';
@@ -52,7 +53,8 @@ const stores = {
     alertStore: AlertStore,
     codeListStore: CodeListStore,
     confirmStore: ConfirmStore,
-    highlightEntityStore: HighlightEntityStore
+    highlightEntityStore: HighlightEntityStore,
+    navigationStore: NavigationStore
 };
 
 ReactDOM.render(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ import LineStore from './stores/lineStore';
 import LinkStore from './stores/linkStore';
 import LoginStore from './stores/loginStore';
 import MapStore from './stores/mapStore';
-import { NavigationStore } from './stores/navigationStore';
+import NavigationStore from './stores/navigationStore';
 import NetworkStore from './stores/networkStore';
 import NodeStore from './stores/nodeStore';
 import PopupStore from './stores/popupStore';

--- a/src/routing/navigator.ts
+++ b/src/routing/navigator.ts
@@ -30,23 +30,11 @@ class Navigator {
         if (this.store.location.pathname === link) return;
 
         const redirect = () => this.store.history.push(link);
-        if (
-            !Boolean(shouldSkipUnsavedChangesPrompt) &&
-            NavigationStore.shouldShowUnsavedChangesPrompt
-        ) {
-            ConfirmStore!.openConfirm({
-                content: unsavedChangesPromptMessage
-                    ? unsavedChangesPromptMessage
-                    : DEFAULT_PROMPT_MESSAGE,
-                onConfirm: () => {
-                    NavigationStore.setShouldShowUnsavedChangesPrompt(false);
-                    redirect();
-                },
-                confirmButtonText: 'Kyllä'
-            });
-        } else {
-            redirect();
-        }
+        this.showUnsavedChangesPrompt({
+            unsavedChangesPromptMessage,
+            shouldSkipUnsavedChangesPrompt,
+            callback: redirect
+        });
     };
 
     // Instead of pushing to a stack (goTo function), replace current url
@@ -90,15 +78,53 @@ class Navigator {
         });
     };
 
-    public goBack() {
-        this.store.goBack();
-    }
+    public goBack = ({
+        unsavedChangesPromptMessage,
+        shouldSkipUnsavedChangesPrompt
+    }: {
+        unsavedChangesPromptMessage?: string;
+        shouldSkipUnsavedChangesPrompt?: boolean;
+    }) => {
+        this.showUnsavedChangesPrompt({
+            unsavedChangesPromptMessage,
+            shouldSkipUnsavedChangesPrompt,
+            callback: this.store.goBack
+        });
+    };
 
     /* not used yet
 
     public goForward() {
         this._store.goForward();
     } */
+
+    private showUnsavedChangesPrompt = ({
+        callback,
+        unsavedChangesPromptMessage,
+        shouldSkipUnsavedChangesPrompt
+    }: {
+        callback: Function;
+        unsavedChangesPromptMessage?: string;
+        shouldSkipUnsavedChangesPrompt?: boolean;
+    }) => {
+        if (
+            !Boolean(shouldSkipUnsavedChangesPrompt) &&
+            NavigationStore.shouldShowUnsavedChangesPrompt
+        ) {
+            ConfirmStore!.openConfirm({
+                content: unsavedChangesPromptMessage
+                    ? unsavedChangesPromptMessage
+                    : DEFAULT_PROMPT_MESSAGE,
+                onConfirm: () => {
+                    NavigationStore.setShouldShowUnsavedChangesPrompt(false);
+                    callback();
+                },
+                confirmButtonText: 'Kyllä'
+            });
+        } else {
+            callback();
+        }
+    };
 }
 
 export default new Navigator();

--- a/src/stores/lineHeaderMassEditStore.ts
+++ b/src/stores/lineHeaderMassEditStore.ts
@@ -3,7 +3,7 @@ import { action, computed, observable, reaction } from 'mobx';
 import { ILineHeader } from '~/models';
 import lineHeaderValidationModel from '~/models/validationModels/lineHeaderValidationModel';
 import FormValidator, { IValidationResult } from '~/validation/FormValidator';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 
 export interface IMassEditLineHeader {
     id: number;
@@ -25,7 +25,7 @@ export class LineHeaderMassEditStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
     }
 

--- a/src/stores/lineHeaderMassEditStore.ts
+++ b/src/stores/lineHeaderMassEditStore.ts
@@ -24,7 +24,7 @@ export class LineHeaderMassEditStore {
         this._isEditingDisabled = true;
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
     }

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -6,7 +6,7 @@ import lineValidationModel, {
     ILineValidationModel
 } from '~/models/validationModels/lineValidationModel';
 import { IValidationResult } from '~/validation/FormValidator';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 export class LineStore {
@@ -23,7 +23,7 @@ export class LineStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
     }

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -22,7 +22,7 @@ export class LineStore {
         this._validationStore = new ValidationStore();
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -36,7 +36,7 @@ export class LinkStore {
         this._validationStore = new ValidationStore();
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);

--- a/src/stores/linkStore.ts
+++ b/src/stores/linkStore.ts
@@ -7,7 +7,7 @@ import linkValidationModel, {
 } from '~/models/validationModels/linkValidationModel';
 import GeometryUndoStore from '~/stores/geometryUndoStore';
 import { calculateLengthFromLatLngs, roundLatLngs } from '~/util/geomHelpers';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 import ValidationStore from './validationStore';
 
 export interface UndoState {
@@ -37,7 +37,7 @@ export class LinkStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
     }

--- a/src/stores/loginStore.ts
+++ b/src/stores/loginStore.ts
@@ -41,7 +41,7 @@ export class LoginStore {
         this._hasWriteAccess = false;
         this._userEmail = undefined;
         if (redirectToLogin) {
-            navigator.goTo(SubSites.login);
+            navigator.goTo({ link: SubSites.login, shouldSkipUnsavedChangesPrompt: true });
         }
     }
 }

--- a/src/stores/navigationStore.ts
+++ b/src/stores/navigationStore.ts
@@ -1,0 +1,23 @@
+import { action, computed, observable } from 'mobx';
+
+export class NavigationStore {
+    @observable private _shouldShowPrompt: boolean;
+
+    constructor() {
+        this._shouldShowPrompt = false;
+    }
+
+    @computed
+    get shouldShowUnsavedChangesPrompt(): boolean {
+        return this._shouldShowPrompt;
+    }
+
+    @action
+    public setShouldShowUnsavedChangesPrompt = (shouldShowPrompt: boolean) => {
+        this._shouldShowPrompt = shouldShowPrompt;
+    };
+}
+
+const observableNavigationStore = new NavigationStore();
+
+export default observableNavigationStore;

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -63,7 +63,7 @@ class NodeStore {
         };
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -17,7 +17,7 @@ import GeometryUndoStore from '~/stores/geometryUndoStore';
 import NodeLocationType from '~/types/NodeLocationType';
 import { roundLatLng, roundLatLngs } from '~/util/geomHelpers';
 import FormValidator from '~/validation/FormValidator';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 interface UndoState {
@@ -64,7 +64,7 @@ class NodeStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(
             () => this._node && this._node.stop && this._node.stop.stopAreaId,

--- a/src/stores/nodeStore.ts
+++ b/src/stores/nodeStore.ts
@@ -359,10 +359,19 @@ class NodeStore {
     };
 
     @action
-    public clearNodeCache = () => {
-        this._nodeCache = {
-            newNodeCache: null
-        };
+    public clearNodeCache = ({
+        nodeId,
+        shouldClearNewNodeCache
+    }: {
+        nodeId?: string;
+        shouldClearNewNodeCache?: boolean;
+    }) => {
+        if (shouldClearNewNodeCache) {
+            this._nodeCache.newNodeCache = null;
+        }
+        if (nodeId) {
+            this._nodeCache[nodeId] = null;
+        }
     };
 
     @action

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -11,7 +11,7 @@ import routePathValidationModel, {
 } from '~/models/validationModels/routePathValidationModel';
 import GeometryUndoStore from '~/stores/geometryUndoStore';
 import { IValidationResult } from '~/validation/FormValidator';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 // Is the neighbor to add either startNode or endNode
@@ -73,7 +73,7 @@ export class RoutePathStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
     }

--- a/src/stores/routePathStore.ts
+++ b/src/stores/routePathStore.ts
@@ -72,7 +72,7 @@ export class RoutePathStore {
         this._routePathLinkValidationStoreMap = new Map();
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);

--- a/src/stores/routeStore.ts
+++ b/src/stores/routeStore.ts
@@ -20,7 +20,7 @@ class RouteStore {
         this._validationStore = new ValidationStore();
 
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && this._routeIdToEdit != null,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
     }

--- a/src/stores/routeStore.ts
+++ b/src/stores/routeStore.ts
@@ -5,7 +5,7 @@ import routeValidationModel, {
     IRouteValidationModel
 } from '~/models/validationModels/routeValidationModel';
 import { IValidationResult } from '~/validation/FormValidator';
-import ToolbarStore from './toolbarStore';
+import NavigationStore from './navigationStore';
 import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 class RouteStore {
@@ -21,7 +21,7 @@ class RouteStore {
 
         reaction(
             () => this.isDirty,
-            (value: boolean) => ToolbarStore.setShouldShowEntityOpenPrompt(value)
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
     }
 

--- a/src/stores/stopAreaStore.ts
+++ b/src/stores/stopAreaStore.ts
@@ -30,7 +30,7 @@ export class StopAreaStore {
 
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
         reaction(
-            () => this.isDirty,
+            () => this.isDirty && !this._isEditingDisabled,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
     }

--- a/src/stores/stopAreaStore.ts
+++ b/src/stores/stopAreaStore.ts
@@ -6,6 +6,7 @@ import { IStopItem } from '~/models/IStop';
 import stopAreaValidationModel, {
     IStopAreaValidationModel
 } from '~/models/validationModels/stopAreaValidationModel';
+import NavigationStore from './navigationStore';
 import ValidationStore from './validationStore';
 
 export interface UndoState {
@@ -28,6 +29,10 @@ export class StopAreaStore {
         this._validationStore = new ValidationStore();
 
         reaction(() => this._isEditingDisabled, this.onChangeIsEditingDisabled);
+        reaction(
+            () => this.isDirty,
+            (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
+        );
     }
 
     @computed


### PR DESCRIPTION
closes #1228 

* Navigator.goTo params refactored as object
* Now every time navigator.goTo is used, prompt will be shown if current store has isDirty = true except when shouldSkipUnsavedPrompt: true is given
* nodeStore's ClearNodeCache method fixed so that it only clears that cache for the currently opened node (before it cleared the whole cache)

Times when unsaved changes prompt is not shown:
* Moving between nodeView & stopAreaView
* Clicking log out button
* Saving & redirecting to new entity

Test that prompts work in every view, every button that changes view. As an example, routePathView's routePathLinks now show prompts!