### PR TITLE
Fetch first and last routePath's stop names

### DIFF
--- a/src/components/shared/loader/Loader.tsx
+++ b/src/components/shared/loader/Loader.tsx
@@ -8,6 +8,7 @@ type loaderSize = 'tiny' | 'small' | 'medium';
 interface ILoaderProps {
     size?: loaderSize;
     hasNoMargin?: boolean;
+    containerClassName?: string;
 }
 
 const Loader = observer((props: ILoaderProps) => (
@@ -15,7 +16,8 @@ const Loader = observer((props: ILoaderProps) => (
         className={classnames(
             s.loaderContainer,
             s[props.size! || 'medium'],
-            props.hasNoMargin ? s.hasNoMargin : undefined
+            props.hasNoMargin ? s.hasNoMargin : undefined,
+            props.containerClassName ? props.containerClassName : undefined
         )}
     >
         <div

--- a/src/components/sidebar/routeListView/RouteItem.tsx
+++ b/src/components/sidebar/routeListView/RouteItem.tsx
@@ -74,6 +74,7 @@ class RouteItem extends React.Component<IRouteItemProps, IRouteItemState> {
                 <ContentList selectedTabIndex={this.state.selectedTabIndex}>
                     <ContentItem>
                         <RoutePathListTab
+                            key={this.props.route.id}
                             route={this.props.route}
                             areAllRoutePathsVisible={this.state.areAllRoutePathsVisible}
                             toggleAllRoutePathsVisible={this.toggleAllRoutePathsVisible}

--- a/src/components/sidebar/routeListView/RouteList.tsx
+++ b/src/components/sidebar/routeListView/RouteList.tsx
@@ -114,7 +114,9 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
             });
         });
         if (!bounds.isValid()) {
-            this.props.mapStore!.initCoordinates();
+            if (this.state.isLoading) {
+                this.props.mapStore!.initCoordinates();
+            }
             return;
         }
 

--- a/src/components/sidebar/routeListView/RouteListView.tsx
+++ b/src/components/sidebar/routeListView/RouteListView.tsx
@@ -1,6 +1,5 @@
 import { inject, observer } from 'mobx-react';
 import React from 'react';
-import { Route } from 'react-router';
 import TransitType from '~/enums/transitType';
 import navigator from '~/routing/navigator';
 import QueryParams from '~/routing/queryParams';
@@ -43,7 +42,7 @@ class RouteListView extends React.Component<IRouteListViewProps> {
             <div className={s.routeListView}>
                 <SearchInput />
                 {this.props.searchStore!.searchInput === '' ? (
-                    <Route component={RouteList} />
+                    <RouteList />
                 ) : (
                     <>
                         <EntityTypeToggles />

--- a/src/components/sidebar/routeListView/routeListView.scss
+++ b/src/components/sidebar/routeListView/routeListView.scss
@@ -3,7 +3,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    width: $sidebarNarrow;
+    width: $sidebarWide;
 
     .routesText {
         font-weight: bold;

--- a/src/components/sidebar/routeListView/routePathListTab.scss
+++ b/src/components/sidebar/routeListView/routePathListTab.scss
@@ -34,16 +34,19 @@
                 font-weight: bold;
             }
 
-            .routePathDate {
-                font-size: $smallFontSize;
-                padding-left: 10px;
-                padding-top: 2px;
+            .stopNameLoader {
                 display: flex;
+                justify-content: center;
+                width: 150px;
+            }
 
-                .dateDeltaSeparator {
-                    min-width: 20px;
-                    text-align: center;
-                }
+            .stopNames {
+                font-size: $mediumFontSize;
+            }
+
+            .routePathPoints {
+                color: $mediumLightGrey;
+                font-size: $smallFontSize;
             }
         }
 

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -83,6 +83,35 @@ const getRoutePathQuery = () => {
         }`;
 };
 
+const getFirstAndLastStopNamesOfRoutePath = () => {
+    return gql`
+        query getRoutePath($routeId: String!, $startDate: Datetime!, $direction: String!) {
+            routePath: reitinsuuntaByReitunnusAndSuuvoimastAndSuusuunta(
+                reitunnus: $routeId
+                suuvoimast: $startDate
+                suusuunta: $direction
+            ) {
+                reitinlinkkisByReitunnusAndSuuvoimastAndSuusuunta {
+                    nodes {
+                        reljarjnro
+                        solmuByLnkalkusolmu {
+                            soltyyppi
+                            pysakkiBySoltunnus {
+                                pysnimi
+                            }
+                        }
+                        solmuByLnkloppusolmu {
+                            pysakkiBySoltunnus {
+                                pysnimi
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+};
+
 const getRoutePathLinkQuery = () => {
     return gql`query getRoutePathLink($routeLinkId: Int!) {
             routePathLink: reitinlinkkiByRelid(relid: $routeLinkId) {
@@ -656,6 +685,7 @@ export default {
     getRouteQuery,
     getAllRoutesQuery,
     getRoutePathQuery,
+    getFirstAndLastStopNamesOfRoutePath,
     getRoutePathLinkQuery,
     getRoutePathSegmentQuery,
     getLinksByStartNodeQuery,

--- a/src/services/routePathService.ts
+++ b/src/services/routePathService.ts
@@ -1,9 +1,12 @@
 import { ApolloQueryResult } from 'apollo-client';
 import Moment from 'moment';
 import EndpointPath from '~/enums/endpointPath';
+import NodeType from '~/enums/nodeType';
 import { IRoutePath, IViaName } from '~/models';
 import { IRoutePathPrimaryKey } from '~/models/IRoutePath';
+import IExternalNode from '~/models/externals/IExternalNode';
 import IExternalRoutePath from '~/models/externals/IExternalRoutePath';
+import IExternalRoutePathLink from '~/models/externals/IExternalRoutePathLink';
 import ApiClient from '~/util/ApiClient';
 import ApolloClient from '~/util/ApolloClient';
 import RoutePathFactory from '../factories/routePathFactory';
@@ -25,6 +28,27 @@ class RoutePathService {
         });
 
         return RoutePathFactory.mapExternalRoutePath(queryResult.data.routePath);
+    };
+
+    public static fetchFirstAndLastStopNamesOfRoutePath = async (
+        routePathPrimaryKey: IRoutePathPrimaryKey
+    ): Promise<Object> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getFirstAndLastStopNamesOfRoutePath(),
+            variables: {
+                routeId: routePathPrimaryKey.routeId,
+                direction: routePathPrimaryKey.direction,
+                startDate: Moment(routePathPrimaryKey.startTime).format()
+            }
+        });
+        const nodes: IExternalRoutePathLink[] =
+            queryResult.data.routePath.reitinlinkkisByReitunnusAndSuuvoimastAndSuusuunta.nodes;
+        nodes.sort((a: IExternalRoutePathLink, b: IExternalRoutePathLink) => a.reljarjnro < b.reljarjnro ? -1 : 1);
+        const stopNames = {
+            firstStopName: _getFirstStopName(nodes),
+            lastStopName: _getLastStopName(nodes)
+        }
+        return stopNames;
     };
 
     public static fetchAllRoutePathPrimaryKeys = async (
@@ -99,5 +123,32 @@ const _getViaNames = (routePath: IRoutePath) => {
     });
     return viaNames;
 };
+
+const _getFirstStopName = (nodes: IExternalRoutePathLink[]) => {
+    for (let i = 0; i < nodes.length; i += 1) {
+        const stopName = _getValidStopName(nodes[i].solmuByLnkalkusolmu);
+        if (stopName) {
+            return stopName;
+        }
+    }
+    return '';
+}
+
+const _getLastStopName = (nodes: IExternalRoutePathLink[]) => {
+    for (let i = nodes.length - 1; i > 0; i -= 1) {
+        const stopName = _getValidStopName(nodes[i].solmuByLnkalkusolmu);
+        if (stopName) {
+            return stopName;
+        }
+    }
+    return '';
+}
+
+const _getValidStopName = (node: IExternalNode): string | null => {
+    if (node.soltyyppi === NodeType.STOP && node.pysakkiBySoltunnus?.pysnimi) {
+        return node.pysakkiBySoltunnus.pysnimi;
+    }
+    return null;
+}
 
 export default RoutePathService;


### PR DESCRIPTION
Closes #1207 

* Fetched routePathLinks need to be sorted because sometimes they are not ordered by orderNumber (e.g. tram http://localhost:3000/routes/?routes[0]=1007M)
* Finding the first / last stop that is not a crossroad. Yes, I could take "relpysakki" (is stop in use) into account but its not worth the time implementing. Also maybe it is a feature, not a bug
