### PR TITLE
Fix save prompt bugs

### DIFF
--- a/src/components/shared/searchView/SearchInput.tsx
+++ b/src/components/shared/searchView/SearchInput.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { inject, observer } from 'mobx-react';
 import React from 'react';
 import { SearchResultStore } from '~/stores/searchResultStore';
@@ -19,14 +20,16 @@ class SearchInput extends React.Component<ISearchInputProps> {
     };
 
     render() {
+        const isDisabled = this.props.searchStore!.isSearchDisabled;
         return (
             <div className={s.lineSearchView}>
-                <div className={s.inputContainer}>
+                <div className={classnames(s.inputContainer, isDisabled ? s.disabled : undefined)}>
                     <input
                         placeholder='Hae'
                         type='text'
                         value={this.props.searchStore!.searchInput}
                         onChange={this.onSearchInputChange}
+                        disabled={isDisabled}
                     />
                     {this.props.searchResultStore!.isSearching && (
                         <div className={s.loader}>

--- a/src/components/shared/searchView/searchInput.scss
+++ b/src/components/shared/searchView/searchInput.scss
@@ -15,4 +15,8 @@
         display: flex;
         flex-direction: column;
     }
+
+    .disabled {
+        pointer-events: none;
+    }
 }

--- a/src/components/sidebar/routeListView/RouteList.tsx
+++ b/src/components/sidebar/routeListView/RouteList.tsx
@@ -152,7 +152,7 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
             .to(SubSites.current, navigator.getQueryParamValues())
             .remove(QueryParams.routes, route.id)
             .toLink();
-        navigator.goTo({ link: closeRouteLink });
+        navigator.goTo({ link: closeRouteLink, shouldSkipUnsavedChangesPrompt: true });
     };
 
     private editRoutePrompt = (route: IRoute) => {
@@ -236,6 +236,7 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
                                     isEditing={isEditing}
                                     isBackButtonVisible={true}
                                     isEditButtonVisible={true}
+                                    isEditPromptHidden={true}
                                     onCloseButtonClick={() => this.closeRoutePrompt(route)}
                                     onEditButtonClick={() => this.editRoutePrompt(route)}
                                 >

--- a/src/components/sidebar/routeListView/RouteList.tsx
+++ b/src/components/sidebar/routeListView/RouteList.tsx
@@ -132,7 +132,10 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
     };
 
     private closeRoutePrompt = (route: IRoute) => {
-        if (this.props.routeStore!.routeIdToEdit === route.id) {
+        if (
+            this.props.routeStore!.routeIdToEdit === route.id &&
+            this.props.routeStore!.shouldShowUnsavedChangesPrompt
+        ) {
             this.props.confirmStore!.openConfirm({
                 content: `Sinulla on tallentamattomia muutoksia. Oletko varma, että haluat sulkea reitin? Tallentamattomat muutokset kumotaan.`,
                 onConfirm: () => {
@@ -148,6 +151,9 @@ class RouteList extends React.Component<IRouteListProps, IRouteListState> {
 
     private closeRoute = (route: IRoute) => {
         this.props.routeListStore!.removeFromRoutes(route.id);
+        if (this.props.routeStore!.routeIdToEdit === route.id) {
+            this.props.routeStore!.clear();
+        }
         const closeRouteLink = routeBuilder
             .to(SubSites.current, navigator.getQueryParamValues())
             .remove(QueryParams.routes, route.id)

--- a/src/routing/navigator.ts
+++ b/src/routing/navigator.ts
@@ -4,7 +4,7 @@ import ConfirmStore from '~/stores/confirmStore';
 import NavigationStore from '~/stores/navigationStore';
 import QueryParams from './queryParams';
 
-const DEFAULT_PROMPT_MESSAGE = `Sinulla on tallentamattomia muutoksia. Poistua näkymästä? Tallentamattomat muutokset kumotaan.`;
+const DEFAULT_PROMPT_MESSAGE = `Sinulla on tallentamattomia muutoksia. Haluatko poistua näkymästä? Tallentamattomat muutokset kumotaan.`;
 
 class Navigator {
     private store: RouterStore;

--- a/src/stores/routeStore.ts
+++ b/src/stores/routeStore.ts
@@ -6,6 +6,7 @@ import routeValidationModel, {
 } from '~/models/validationModels/routeValidationModel';
 import { IValidationResult } from '~/validation/FormValidator';
 import NavigationStore from './navigationStore';
+import SearchStore from './searchStore';
 import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 class RouteStore {
@@ -22,6 +23,10 @@ class RouteStore {
         reaction(
             () => this.isDirty && this._routeIdToEdit != null,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
+        );
+        reaction(
+            () => this._routeIdToEdit != null,
+            (value: boolean) => SearchStore.setIsSearchDisabled(value)
         );
     }
 

--- a/src/stores/routeStore.ts
+++ b/src/stores/routeStore.ts
@@ -21,7 +21,7 @@ class RouteStore {
         this._validationStore = new ValidationStore();
 
         reaction(
-            () => this.isDirty && this._routeIdToEdit != null,
+            () => this.shouldShowUnsavedChangesPrompt,
             (value: boolean) => NavigationStore.setShouldShowUnsavedChangesPrompt(value)
         );
         reaction(
@@ -63,6 +63,11 @@ class RouteStore {
             _.omit(this._route, ['line', 'routePaths']),
             _.omit(this._oldRoute, ['line', 'routePaths'])
         );
+    }
+
+    @computed
+    get shouldShowUnsavedChangesPrompt(): boolean {
+        return this.isDirty && this._routeIdToEdit != null;
     }
 
     @computed

--- a/src/stores/searchStore.ts
+++ b/src/stores/searchStore.ts
@@ -6,6 +6,7 @@ export class SearchStore {
     @observable private _selectedTransitTypes: TransitType[];
     @observable private _isSearchingForLines: boolean;
     @observable private _isSearchingForNodes: boolean;
+    @observable private _isSearchDisabled: boolean;
 
     constructor() {
         this._searchInput = '';
@@ -18,6 +19,7 @@ export class SearchStore {
         ];
         this._isSearchingForLines = true;
         this._isSearchingForNodes = true;
+        this._isSearchDisabled = false;
     }
 
     @computed
@@ -45,6 +47,11 @@ export class SearchStore {
         return this._isSearchingForNodes;
     }
 
+    @computed
+    get isSearchDisabled() {
+        return this._isSearchDisabled;
+    }
+
     @action
     public toggleIsSearchingForLines() {
         this._isSearchingForLines = !this._isSearchingForLines;
@@ -64,6 +71,11 @@ export class SearchStore {
             this._selectedTransitTypes = this._selectedTransitTypes.concat(type);
         }
     };
+
+    @action
+    public setIsSearchDisabled(isSearchDisabled: boolean) {
+        this._isSearchDisabled = isSearchDisabled;
+    }
 }
 
 const observableSearchStore = new SearchStore();


### PR DESCRIPTION
Had to disable searchBar if isEditing at routesPage. Reason: selecting a new route caused routes page to re-render (routeStore gets cleared due to routeList unmount call). Surely there could be a better fix but this is what I came up with.

Had to simplify the Navigator / sidebarHeader idea:

- navigator
    - close (might show prompt)
    - go back (might show prompt)

- sidebarHeader
    - if isEditPromptHidden = true, calls custom onEditButtonClick method
    - if isEditPromptHidden = true, might show prompt, then calls custom onEditButtonClick method

    - default close, calls navigator.close (can pass custom closeButtonMessage to navigator.close)
    - default back, calls navigator.goBack (can pass custom backButtonMessage to navigator.goBack)

    - calls custom onCloseButtonClick if method is given (might show prompt if defined at onCloseClick callback)
    - calls custom onBackButtonClick if method is given (might show prompt if defined at onBackButtonClick callback)


Test carefully. There are many combinations to test.