### PR TITLE
Reduced decimals in geometries, fixed node savePrompt diff

### DIFF
--- a/src/components/sidebar/nodeView/NodeView.tsx
+++ b/src/components/sidebar/nodeView/NodeView.tsx
@@ -286,9 +286,14 @@ class NodeView extends React.Component<INodeViewProps, INodeViewState> {
         const oldStop = _.cloneDeep(oldNode.stop);
 
         // Create node save model
-        if (currentNode.stop) {
+        if (currentStop) {
             delete currentNode['stop'];
             delete oldNode['stop'];
+
+            if (currentNode.type === NodeType.CROSSROAD || currentNode.type === NodeType.MUNICIPALITY_BORDER) {
+                delete currentNode['measurementType'];
+                delete currentNode['coordinatesProjection'];
+            }
         }
         const saveModels: ISaveModel[] = [
             {

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -6,13 +6,15 @@ if (process.env.NODE_ENV === 'development') {
 } else {
     APP_URL = `https://${process.env.ENVIRONMENT}.${process.env.DOMAIN_NAME}`;
 }
-const environment: Environment = process.env.ENVIRONMENT ? process.env.ENVIRONMENT as Environment : Environment.LOCALHOST;
+const environment: Environment = process.env.ENVIRONMENT
+    ? (process.env.ENVIRONMENT as Environment)
+    : Environment.LOCALHOST;
 
 const commonConstants = {
     ENVIRONMENT: environment,
     BUILD_DATE: process.env.BUILD_DATE,
     AFTER_LOGIN_URL: `${APP_URL}/afterLogin`,
-    DECIMALS_IN_GEOMETRIES: 8,
+    DECIMALS_IN_GEOMETRIES: 6,
     INTEGER_MAX_VALUE: 2147483647, // Max value at PostgreSQL (4 bytes)
     SMALL_INT_MAX_VALUE: 32767, // Max value at PostgreSQL (2 bytes)
     MAP_LAYERS_MIN_ZOOM_LEVEL: 13,

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -14,7 +14,7 @@ const commonConstants = {
     ENVIRONMENT: environment,
     BUILD_DATE: process.env.BUILD_DATE,
     AFTER_LOGIN_URL: `${APP_URL}/afterLogin`,
-    DECIMALS_IN_GEOMETRIES: 6,
+    DECIMALS_IN_GEOMETRIES: 6, // Max value 6 currenlty at joredb columns: numeric(8,6)
     INTEGER_MAX_VALUE: 2147483647, // Max value at PostgreSQL (4 bytes)
     SMALL_INT_MAX_VALUE: 32767, // Max value at PostgreSQL (2 bytes)
     MAP_LAYERS_MIN_ZOOM_LEVEL: 13,


### PR DESCRIPTION
Closes #1128 

Reduced decimals to 6 because backend's columns have max 6 decimals: numeric(8,6)