### PR TITLE
1265 refactoring: removed ILine.routes and IRoute.line (optimized routes query at line page)

### DIFF
--- a/src/codeLists/propertyCodeLists.ts
+++ b/src/codeLists/propertyCodeLists.ts
@@ -68,7 +68,6 @@ const routePropertyCodeList: IRoutePropertyCodeList = {
     routeNameSw: 'NIMI RUOTSIKSI',
     routeNameShortSw: 'LYHYT NIMI RUOTSIKSI',
     lineId: '',
-    line: '',
     modifiedBy: 'MUOKANNUT',
     modifiedOn: 'MUOKATTU PVM'
 };
@@ -100,8 +99,7 @@ const linePropertyCodeList: ILinePropertyCodeList = {
     modifiedOn: '',
     publicTransportDestination: 'JOUKKOLIIKENNEKOHDE',
     exchangeTime: 'VAIHTOAJAN PIDENNYS (min)',
-    lineReplacementType: 'LINJAN KORVAAVA TYYPPI',
-    routes: ''
+    lineReplacementType: 'LINJAN KORVAAVA TYYPPI'
 };
 
 type RoutePathKeys = keyof IRoutePath;

--- a/src/components/sidebar/lineView/LineRoutesTab.tsx
+++ b/src/components/sidebar/lineView/LineRoutesTab.tsx
@@ -70,16 +70,18 @@ class LineRoutesTab extends React.Component<ILineRoutesTabProps> {
     };
 
     render() {
-        const line = this.props.lineStore!.line;
+        const lineStore = this.props.lineStore!;
+        const line = lineStore.line;
+        const routes = lineStore.routes;
         if (!line) return null;
 
         return (
             <div className={s.lineRoutesTabView} data-cy='lineRoutesTabView'>
                 <div className={s.content}>
-                    {line.routes.length === 0 ? (
+                    {routes.length === 0 ? (
                         <div>Linjalla ei olemassa olevia reittejä.</div>
                     ) : (
-                        this.renderRouteList(line.routes)
+                        this.renderRouteList(routes)
                     )}
 
                     {this.props.loginStore!.hasWriteAccess && (

--- a/src/components/sidebar/lineView/LineView.tsx
+++ b/src/components/sidebar/lineView/LineView.tsx
@@ -9,7 +9,6 @@ import navigator from '~/routing/navigator';
 import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import LineService from '~/services/lineService';
-import RouteService from '~/services/routeService';
 import { AlertStore } from '~/stores/alertStore';
 import { ConfirmStore } from '~/stores/confirmStore';
 import { ErrorStore } from '~/stores/errorStore';
@@ -99,10 +98,9 @@ class LineView extends React.Component<ILineViewProps, ILineViewState> {
     private initExistingLine = async () => {
         const lineId = this.props.match!.params.id;
         try {
-            const line = await LineService.fetchLine(lineId);
-            const routes = await RouteService.fetchAllRoutesByLineId(lineId);
-            line.routes = routes;
+            const { line, routes } = await LineService.fetchLineAndRoutes(lineId);
             this.props.lineStore!.init({ line, isNewLine: false });
+            this.props.lineStore!.setRoutes(routes);
         } catch (e) {
             this.props.errorStore!.addError('Linjan haku epäonnistui.', e);
         }

--- a/src/components/sidebar/routePathView/RoutePathView.tsx
+++ b/src/components/sidebar/routePathView/RoutePathView.tsx
@@ -19,7 +19,6 @@ import routeBuilder from '~/routing/routeBuilder';
 import SubSites from '~/routing/subSites';
 import LineService from '~/services/lineService';
 import RoutePathService from '~/services/routePathService';
-import RouteService from '~/services/routeService';
 import ViaNameService from '~/services/viaNameService';
 import { AlertStore } from '~/stores/alertStore';
 import { ConfirmStore } from '~/stores/confirmStore';
@@ -121,8 +120,8 @@ class RoutePathView extends React.Component<IRoutePathViewProps, IRoutePathViewS
                 const queryParams = navigator.getQueryParamValues();
                 const routeId = queryParams[QueryParams.routeId];
                 const lineId = queryParams[QueryParams.lineId];
-                const route = await RouteService.fetchRoute(routeId);
-                const routePath = RoutePathFactory.createNewRoutePath(lineId, route);
+                const line = await LineService.fetchLine(lineId);
+                const routePath = RoutePathFactory.createNewRoutePath(lineId, routeId, line.transitType!);
                 this.props.routePathStore!.init({ routePath, isNewRoutePath: this.props.isNewRoutePath });
             } else {
                 this.props.routePathStore!.init({

--- a/src/factories/lineFactory.ts
+++ b/src/factories/lineFactory.ts
@@ -6,9 +6,8 @@ import ISearchLineRoute from '~/models/searchModels/ISearchLineRoute';
 import { toMidnightDate } from '~/util/dateHelpers';
 
 class LineFactory {
-    public static createLine = (externalLine: IExternalLine): ILine => {
+    public static mapExternalLine = (externalLine: IExternalLine): ILine => {
         return {
-            routes: [],
             transitType: externalLine.linverkko,
             id: externalLine.lintunnus,
             lineBasicRoute: externalLine.linperusreitti,
@@ -28,7 +27,6 @@ class LineFactory {
         const defaultDate = toMidnightDate(new Date());
 
         return {
-            routes: [],
             id: '',
             lineBasicRoute: '',
             lineStartDate: new Date(defaultDate),

--- a/src/factories/routeFactory.ts
+++ b/src/factories/routeFactory.ts
@@ -1,10 +1,10 @@
-import { ILine, IRoute, IRoutePath } from '~/models';
+import { IRoute, IRoutePath } from '~/models';
 import IExternalRoute from '~/models/externals/IExternalRoute.ts';
 import IExternalRoutePath from '~/models/externals/IExternalRoutePath.ts';
 import RoutePathFactory from './routePathFactory';
 
 class RouteFactory {
-    public static mapExternalRoute = (externalRoute: IExternalRoute, line?: ILine): IRoute => {
+    public static mapExternalRoute = (externalRoute: IExternalRoute): IRoute => {
         const routePaths: IRoutePath[] = externalRoute.reitinsuuntasByReitunnus.nodes.map(
             (routePath: IExternalRoutePath) => {
                 return RoutePathFactory.mapExternalRoutePath(routePath);
@@ -12,7 +12,6 @@ class RouteFactory {
         );
 
         return {
-            line,
             routePaths: routePaths.sort((a, b) => b.endTime.getTime() - a.endTime.getTime()),
             routeName: externalRoute.reinimi,
             routeNameShort: externalRoute.reinimilyh,

--- a/src/factories/routeFactory.ts
+++ b/src/factories/routeFactory.ts
@@ -1,18 +1,13 @@
 import { IRoute, IRoutePath } from '~/models';
 import IExternalRoute from '~/models/externals/IExternalRoute.ts';
-import IExternalRoutePath from '~/models/externals/IExternalRoutePath.ts';
-import RoutePathFactory from './routePathFactory';
 
 class RouteFactory {
-    public static mapExternalRoute = (externalRoute: IExternalRoute): IRoute => {
-        const routePaths: IRoutePath[] = externalRoute.reitinsuuntasByReitunnus.nodes.map(
-            (routePath: IExternalRoutePath) => {
-                return RoutePathFactory.mapExternalRoutePath(routePath);
-            }
-        );
-
+    public static mapExternalRoute = (
+        externalRoute: IExternalRoute,
+        routePaths?: IRoutePath[]
+    ): IRoute => {
         return {
-            routePaths: routePaths.sort((a, b) => b.endTime.getTime() - a.endTime.getTime()),
+            routePaths: routePaths ? routePaths : [],
             routeName: externalRoute.reinimi,
             routeNameShort: externalRoute.reinimilyh,
             routeNameSw: externalRoute.reinimir,

--- a/src/factories/routePathFactory.ts
+++ b/src/factories/routePathFactory.ts
@@ -1,4 +1,5 @@
-import { IRoute, IRoutePath, IRoutePathLink } from '~/models';
+import TransitType from '~/enums/transitType';
+import { IRoutePath, IRoutePathLink } from '~/models';
 import { IRoutePathPrimaryKey } from '~/models/IRoutePath';
 import IExternalRoutePath from '~/models/externals/IExternalRoutePath.ts';
 import IExternalRoutePathLink from '~/models/externals/IExternalRoutePathLink.ts';
@@ -67,14 +68,18 @@ class RoutePathFactory {
         };
     };
 
-    public static createNewRoutePath(lineId: string, route: IRoute): IRoutePath {
+    public static createNewRoutePath(
+        lineId: string,
+        routeId: string,
+        transitType: TransitType
+    ): IRoutePath {
         const defaultDate = new Date();
         defaultDate.setHours(0, 0, 0, 0);
 
         return {
             lineId,
-            transitType: route.line!.transitType!,
-            routeId: route.id,
+            routeId,
+            transitType,
             internalId: '',
             name: '',
             nameSw: '',

--- a/src/models/ILine.ts
+++ b/src/models/ILine.ts
@@ -1,12 +1,10 @@
 import TransitType from '~/enums/transitType';
-import { IRoute } from '.';
 
 interface ILinePrimaryKey {
     id: string;
 }
 
 export default interface ILine extends ILinePrimaryKey {
-    routes: IRoute[];
     transitType?: TransitType;
     lineBasicRoute: string;
     lineStartDate: Date;

--- a/src/models/IRoute.ts
+++ b/src/models/IRoute.ts
@@ -1,4 +1,4 @@
-import { ILine, IRoutePath } from '.';
+import { IRoutePath } from '.';
 
 interface IRoutePrimaryKey {
     id: string;
@@ -11,7 +11,6 @@ export default interface IRoute extends IRoutePrimaryKey {
     routeNameSw: string;
     routeNameShortSw: string;
     lineId: string;
-    line?: ILine;
     modifiedBy?: string;
     modifiedOn?: Date;
 }

--- a/src/models/validationModels/lineValidationModel.ts
+++ b/src/models/validationModels/lineValidationModel.ts
@@ -8,7 +8,6 @@ type ILineValidationModel = { [key in LineKeys]: string };
 // TODO: rename as lineValidationObject
 const lineValidationModel: ILineValidationModel = {
     id: `required|min:4|max:6|string|${regexRules.upperCaseOrNumbersOrSpace}`,
-    routes: '',
     transitType: 'required|min:1|max:1|string',
     lineBasicRoute: 'required|min:4|max:6|string',
     lineStartDate: 'required|date',

--- a/src/models/validationModels/routeValidationModel.ts
+++ b/src/models/validationModels/routeValidationModel.ts
@@ -12,7 +12,6 @@ const routeValidationModel: IRouteValidationModel = {
     routeNameSw: 'required|min:1|max:60|string',
     routeNameShortSw: 'required|min:1|max:20|string',
     lineId: 'required|min:4|max:6|string',
-    line: '',
     modifiedBy: '',
     modifiedOn: ''
 };

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -14,8 +14,7 @@ const getLineAndRoutesQuery = () => {
                 ${lineQueryFields}
                 reittisByLintunnus(orderBy: REIVIIMPVM_DESC) {
                     nodes {
-                        reinimi
-                        reiviimpvm
+                        ${routeQueryFields}
                     }
                 }
             }

--- a/src/services/graphqlQueries.ts
+++ b/src/services/graphqlQueries.ts
@@ -4,6 +4,14 @@ const getLineQuery = () => {
     return gql`query getLineByLintunnus ($lineId: String!) {
             linjaByLintunnus(lintunnus:$lineId) {
                 ${lineQueryFields}
+            }
+        }`;
+};
+
+const getLineAndRoutesQuery = () => {
+    return gql`query getLineByLintunnus ($lineId: String!) {
+            linjaByLintunnus(lintunnus:$lineId) {
+                ${lineQueryFields}
                 reittisByLintunnus(orderBy: REIVIIMPVM_DESC) {
                     nodes {
                         reinimi
@@ -679,6 +687,7 @@ linkkisByLnkloppusolmu {
 
 export default {
     getLineQuery,
+    getLineAndRoutesQuery,
     getSearchLineQuery,
     getAllSearchLinesQuery,
     getLinkQuery,

--- a/src/services/lineService.ts
+++ b/src/services/lineService.ts
@@ -1,8 +1,10 @@
 import { ApolloQueryResult } from 'apollo-client';
 import EndpointPath from '~/enums/endpointPath';
 import LineFactory from '~/factories/lineFactory';
+import RouteFactory from '~/factories/routeFactory';
 import { ILine, IRoute } from '~/models';
 import { ILinePrimaryKey } from '~/models/ILine';
+import IExternalRoute from '~/models/externals/IExternalRoute';
 import ISearchLine from '~/models/searchModels/ISearchLine';
 import ApiClient from '~/util/ApiClient';
 import ApolloClient from '~/util/ApolloClient';
@@ -42,10 +44,13 @@ class LineService {
             query: GraphqlQueries.getLineAndRoutesQuery(),
             variables: { lineId: lintunnus }
         });
-        console.log('at fetchLineAndRoutes queryResult.data ', queryResult.data);
+        const externalLine = queryResult.data.linjaByLintunnus;
+        const externalRoutes = externalLine.reittisByLintunnus.nodes;
         return {
-            line: LineFactory.mapExternalLine(queryResult.data.linjaByLintunnus),
-            routes: [] // TODO
+            line: LineFactory.mapExternalLine(externalLine),
+            routes: externalRoutes.map((externalRoute: IExternalRoute) =>
+                RouteFactory.mapExternalRoute(externalRoute)
+            )
         };
     };
 

--- a/src/services/lineService.ts
+++ b/src/services/lineService.ts
@@ -1,7 +1,7 @@
 import { ApolloQueryResult } from 'apollo-client';
 import EndpointPath from '~/enums/endpointPath';
 import LineFactory from '~/factories/lineFactory';
-import { ILine } from '~/models';
+import { ILine, IRoute } from '~/models';
 import { ILinePrimaryKey } from '~/models/ILine';
 import ISearchLine from '~/models/searchModels/ISearchLine';
 import ApiClient from '~/util/ApiClient';
@@ -14,8 +14,39 @@ class LineService {
             query: GraphqlQueries.getLineQuery(),
             variables: { lineId: lintunnus }
         });
+        return LineFactory.mapExternalLine(queryResult.data.linjaByLintunnus);
+    };
 
-        return LineFactory.createLine(queryResult.data.linjaByLintunnus);
+    public static fetchMultipleLines = async (lineIds: string[]): Promise<ILine[]> => {
+        const promises: Promise<void>[] = [];
+        const lines: ILine[] = [];
+        lineIds.map((lineId: string) => {
+            const createPromise = async () => {
+                const route = await LineService.fetchLine(lineId);
+                lines.push(route);
+            };
+            promises.push(createPromise());
+        });
+
+        await Promise.all(promises);
+        return lines;
+    };
+
+    public static fetchLineAndRoutes = async (
+        lintunnus: string
+    ): Promise<{
+        line: ILine;
+        routes: IRoute[];
+    }> => {
+        const queryResult: ApolloQueryResult<any> = await ApolloClient.query({
+            query: GraphqlQueries.getLineAndRoutesQuery(),
+            variables: { lineId: lintunnus }
+        });
+        console.log('at fetchLineAndRoutes queryResult.data ', queryResult.data);
+        return {
+            line: LineFactory.mapExternalLine(queryResult.data.linjaByLintunnus),
+            routes: [] // TODO
+        };
     };
 
     public static fetchAllSearchLines = async (): Promise<ISearchLine[]> => {

--- a/src/services/routeService.ts
+++ b/src/services/routeService.ts
@@ -1,8 +1,10 @@
 import { ApolloQueryResult } from 'apollo-client';
 import EndpointPath from '~/enums/endpointPath';
 import RouteFactory from '~/factories/routeFactory';
-import { IRoute } from '~/models';
+import RoutePathFactory from '~/factories/routePathFactory';
+import { IRoute, IRoutePath } from '~/models';
 import { IRoutePrimaryKey } from '~/models/IRoute';
+import IExternalRoutePath from '~/models/externals/IExternalRoutePath';
 import ApiClient from '~/util/ApiClient';
 import ApolloClient from '~/util/ApolloClient';
 import GraphqlQueries from './graphqlQueries';
@@ -21,7 +23,13 @@ class RouteService {
             query: GraphqlQueries.getRouteQuery(Boolean(areRoutePathLinksExcluded)),
             variables: { routeId }
         });
-        return RouteFactory.mapExternalRoute(queryResult.data.route);
+        const externalRoute = queryResult.data.route;
+        const externalRoutePaths = externalRoute.reitinsuuntasByReitunnus.nodes;
+        const routePaths: IRoutePath[] = externalRoutePaths.map((routePath: IExternalRoutePath) => {
+            return RoutePathFactory.mapExternalRoutePath(routePath);
+        });
+        routePaths.sort((a, b) => b.endTime.getTime() - a.endTime.getTime());
+        return RouteFactory.mapExternalRoute(queryResult.data.route, routePaths);
     };
 
     public static fetchMultipleRoutes = async (routeIds: string[]): Promise<IRoute[]> => {

--- a/src/stores/lineStore.ts
+++ b/src/stores/lineStore.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { action, computed, observable, reaction } from 'mobx';
-import { ILine } from '~/models';
+import { ILine, IRoute } from '~/models';
 import ISearchLine from '~/models/searchModels/ISearchLine';
 import lineValidationModel, {
     ILineValidationModel
@@ -11,6 +11,7 @@ import ValidationStore, { ICustomValidatorMap } from './validationStore';
 
 export class LineStore {
     @observable private _line: ILine | null;
+    @observable private _routes: IRoute[];
     @observable private _oldline: ILine | null;
     @observable private _isNewLine: boolean;
     @observable private _isEditingDisabled: boolean;
@@ -31,6 +32,11 @@ export class LineStore {
     @computed
     get line(): ILine | null {
         return this._line;
+    }
+
+    @computed
+    get routes(): IRoute[] {
+        return this._routes;
     }
 
     @computed
@@ -111,6 +117,11 @@ export class LineStore {
 
         this._validationStore.init(line, lineValidationModel, customValidatorMap);
     };
+
+    @action
+    public setRoutes = (routes: IRoute[]) => {
+        this._routes = routes;
+    }
 
     @action
     public setOldLine = (line: ILine) => {

--- a/src/stores/routeListStore.ts
+++ b/src/stores/routeListStore.ts
@@ -1,14 +1,16 @@
 import { action, computed, observable } from 'mobx';
-import { IRoute, IRoutePath } from '~/models';
+import { ILine, IRoute, IRoutePath } from '~/models';
 import RoutePathService from '~/services/routePathService';
 import ColorScale from '~/util/ColorScale';
 
 export class RouteListStore {
     @observable private _routes: IRoute[];
+    @observable private _lines: ILine[];
     private colorScale: ColorScale;
 
     constructor() {
         this._routes = [];
+        this._lines = [];
         this.colorScale = new ColorScale();
     }
 
@@ -17,9 +19,18 @@ export class RouteListStore {
         return this._routes;
     }
 
+    public getLine(lineId: string): ILine | undefined {
+        return this._lines.find(line => line.id === lineId);
+    }
+
     @action
     public addToRoutes = (routes: IRoute[]) => {
         this._routes = this._routes.concat(routes);
+    };
+
+    @action
+    public addToLines = (lines: ILine[]) => {
+        this._lines = this._lines.concat(lines);
     };
 
     @action


### PR DESCRIPTION
Closes #1265 

Refactored architecture a bit, no more confusing two-way binding with having ILine.routes & IRoute.line